### PR TITLE
v1.5.3 - fullscreen support, and include code quality improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,5 @@ GEMINI.md
 ACTIONS_SETUP.md
 .gemini/
 buildServer.json
+
+*hint-note.md

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ xattr -d com.apple.quarantine /Applications/StoneClipboarderTool.app
 ## Features
 
 ### 🆕 New in Version 1.5.x
+- **🪟 Fullscreen Support (1.5.3)**: Quick Picker and menu bar popover now render over other apps' fullscreen Spaces — open them without leaving the app you're in
+- **🔍 Smart Preview Fallback (1.5.3)**: When triggering preview inside a fullscreen app, the custom preview is used automatically (Apple Quick Look is system-managed and can't render there)
+- **🛠️ Quick Picker Stability (1.5.3)**: Fixed Quick Picker pulling you out of fullscreen, improved QuickLook temp-file cleanup timing, cleaner window resignation handling
+- **🧹 Code Quality (1.5.3)**: SonarCloud refactor — code quality improvements across the codebase
 - **🛡️ Accessibility Settings Tab**: New settings tab showing accessibility permission status with direct link to System Settings
 - **🚀 Launch at Login**: Toggle auto-start at login via SMAppService, with first-launch prompt
 - **🎨 Improved Quick Picker**: Better item row layout, footer bar with keyboard shortcut hints, pagination and search improvements

--- a/StoneClipboarderTool.xcodeproj/project.pbxproj
+++ b/StoneClipboarderTool.xcodeproj/project.pbxproj
@@ -275,7 +275,7 @@
 				CODE_SIGN_ENTITLEMENTS = StoneClipboarderTool/StoneClipboarderTool.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 729B6K44G8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -289,7 +289,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.5.2;
+				MARKETING_VERSION = 1.5.3;
 				PRODUCT_BUNDLE_IDENTIFIER = d3f0ld.StoneClipboarderTool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -306,7 +306,7 @@
 				CODE_SIGN_ENTITLEMENTS = StoneClipboarderTool/StoneClipboarderTool.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 729B6K44G8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -320,7 +320,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.5.2;
+				MARKETING_VERSION = 1.5.3;
 				PRODUCT_BUNDLE_IDENTIFIER = d3f0ld.StoneClipboarderTool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/StoneClipboarderTool/Info.plist
+++ b/StoneClipboarderTool/Info.plist
@@ -2,32 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
-	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
-	<key>CFBundleVersion</key>
-	<string>8</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
+	<key>SUAutomaticallyUpdate</key>
+	<true/>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
 	<key>SUFeedURL</key>
 	<string>https://foxfollow.github.io/Stone-Clipboarder-Tool/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>yJrsF5A8PAUhQBx9s4M89LH6VhiCpKS+FlHr2xUIa84=</string>
-	<key>SUEnableAutomaticChecks</key>
-	<true/>
-	<key>SUAutomaticallyUpdate</key>
-	<true/>
 	<key>SUScheduledCheckInterval</key>
 	<integer>86400</integer>
 </dict>

--- a/StoneClipboarderTool/Manager/ClipboardManager.swift
+++ b/StoneClipboarderTool/Manager/ClipboardManager.swift
@@ -352,17 +352,23 @@ class ClipboardManager: ObservableObject {
                         }
                     }
 
-                    await MainActor.run {
-                        print("File saved successfully")
-                    }
+                    await self.logSuccessOnMain()
 
                 } catch {
-                    await MainActor.run {
-                        print("Error saving file: \(error.localizedDescription)")
-                    }
+                    await self.logErrorOnMain(error)
                 }
             }
         }
+    }
+    
+    @MainActor
+    private func logSuccessOnMain() {
+        print("File saved successfully")
+    }
+    
+    @MainActor
+    private func logErrorOnMain(_ error: Error) {
+        print("Error saving file: \(error.localizedDescription)")
     }
     
     func copyItemToClipboard(_ item: CBItem) {

--- a/StoneClipboarderTool/Manager/ErrorLogger.swift
+++ b/StoneClipboarderTool/Manager/ErrorLogger.swift
@@ -31,7 +31,7 @@ class ErrorLogger {
         return appDir.appendingPathComponent(logFileName)
     }
 
-    private init() {}
+    private init() { /* Private initialization to ensure singleton usage */ }
 
     /// Log an error. Always prints to console. Writes to file if file logging is enabled.
     func log(_ message: String, category: String = "General", error: Error? = nil) {

--- a/StoneClipboarderTool/Manager/HotkeyManager.swift
+++ b/StoneClipboarderTool/Manager/HotkeyManager.swift
@@ -306,46 +306,18 @@ class HotkeyManager: ObservableObject {
     }
 
     private func keyCodeForCharacter(_ character: String) -> UInt32? {
-        switch character.lowercased() {
-        case "1": return 18
-        case "2": return 19
-        case "3": return 20
-        case "4": return 21
-        case "5": return 23
-        case "6": return 22
-        case "7": return 26
-        case "8": return 28
-        case "9": return 25
-        case "0": return 29
-        case "space": return 49
-        case "a": return 0
-        case "b": return 11
-        case "c": return 8
-        case "d": return 2
-        case "e": return 14
-        case "f": return 3
-        case "g": return 5
-        case "h": return 4
-        case "i": return 34
-        case "j": return 38
-        case "k": return 40
-        case "l": return 37
-        case "m": return 46
-        case "n": return 45
-        case "o": return 31
-        case "p": return 35
-        case "q": return 12
-        case "r": return 15
-        case "s": return 1
-        case "t": return 17
-        case "u": return 32
-        case "v": return 9
-        case "w": return 13
-        case "x": return 7
-        case "y": return 16
-        case "z": return 6
-        default: return nil
-        }
+        let characterMap: [String: UInt32] = [
+            "1": 18, "2": 19, "3": 20, "4": 21, "5": 23,
+            "6": 22, "7": 26, "8": 28, "9": 25, "0": 29,
+            "space": 49,
+            "a": 0, "b": 11, "c": 8, "d": 2, "e": 14,
+            "f": 3, "g": 5, "h": 4, "i": 34, "j": 38,
+            "k": 40, "l": 37, "m": 46, "n": 45, "o": 31,
+            "p": 35, "q": 12, "r": 15, "s": 1, "t": 17,
+            "u": 32, "v": 9, "w": 13, "x": 7, "y": 16,
+            "z": 6
+        ]
+        return characterMap[character.lowercased()]
     }
 
     // MARK: - Actions

--- a/StoneClipboarderTool/Manager/MenuBarManager.swift
+++ b/StoneClipboarderTool/Manager/MenuBarManager.swift
@@ -102,6 +102,7 @@ class MenuBarManager: ObservableObject {
                 popover.performClose(sender)
             } else {
                 popover.show(relativeTo: button.bounds, of: button, preferredEdge: NSRectEdge.minY)
+                makePopoverFullscreenSafe(popover)
             }
         } else {
             // Recreate popover if it's nil
@@ -109,8 +110,23 @@ class MenuBarManager: ObservableObject {
             // Try again after refresh
             if let popover = popover {
                 popover.show(relativeTo: button.bounds, of: button, preferredEdge: NSRectEdge.minY)
+                makePopoverFullscreenSafe(popover)
             }
         }
+    }
+
+    /// NSPopover's internal window doesn't carry .canJoinAllSpaces /
+    /// .fullScreenAuxiliary by default, so it can't render alongside another
+    /// app's fullscreen Space. Patching the collection behavior right after
+    /// show() lets the popover appear without forcing a Space switch.
+    /// Window level is left at NSPopover's default to avoid interfering with
+    /// other floating UI (e.g. QuickLook).
+    @MainActor
+    private func makePopoverFullscreenSafe(_ popover: NSPopover) {
+        guard let popoverWindow = popover.contentViewController?.view.window else { return }
+        popoverWindow.collectionBehavior = [
+            .canJoinAllSpaces, .fullScreenAuxiliary, .transient
+        ]
     }
 
     /// Update the menu bar icon based on pause state

--- a/StoneClipboarderTool/Manager/QuickPickerWindowManager.swift
+++ b/StoneClipboarderTool/Manager/QuickPickerWindowManager.swift
@@ -14,14 +14,12 @@ class QuickPickerHostingView: NSHostingView<QuickPickerView> {
         return true
     }
 
-    override func becomeFirstResponder() -> Bool {
-        let result = super.becomeFirstResponder()
-        // Ensure the hosting view can receive keyboard events
-        DispatchQueue.main.async {
-            self.window?.makeFirstResponder(self)
-        }
-        return result
-    }
+    // No becomeFirstResponder override here. A previous version re-asserted
+    // self as first responder on the next runloop tick, which fired *after*
+    // SwiftUI's @FocusState routed focus to the search TextField's field
+    // editor — kicking the cursor out of the search box. SwiftUI's onKeyPress
+    // handlers fire on the parent view regardless of which child is focused,
+    // so we don't need to force the hosting view to stay first responder.
 
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
         return true
@@ -34,10 +32,9 @@ class KeyCapturingPanel: NSPanel {
     override var canBecomeKey: Bool {
         return true
     }
-
-    override var canBecomeMain: Bool {
-        return canBecomeKey  // Allow it to become main to receive proper focus
-    }
+    // canBecomeMain intentionally not overridden — NSPanel's default is false,
+    // which is what we want so .nonactivatingPanel + canJoinAllSpaces can
+    // render over another app's fullscreen Space without triggering activation.
 
     override var acceptsFirstResponder: Bool {
         return canBecomeKey
@@ -117,16 +114,23 @@ class QuickPickerWindowManager: NSObject, ObservableObject, QuickPickerDelegate 
 
         // Store the currently active app so we can return focus to it later
         previousApp = NSWorkspace.shared.frontmostApplication
-        
-        // Hide ALL other windows to ensure QuickPicker is the only one visible
+
+        // Hide our other windows so the QuickPicker is the only one visible.
+        // orderOut on its own does NOT trigger a Space switch — only NSApp.activate
+        // and activation-policy changes do. Safe to do this in any context.
         for window in NSApp.windows {
             window.orderOut(nil)
         }
 
-        // Create a panel that captures focus without activating the main app
+        // Create a borderless non-activating panel. .nonactivatingPanel is
+        // required for the picker to render over another app's fullscreen
+        // Space without forcing a Space switch; SwiftUI @FocusState is
+        // unreliable in this configuration, so focusSearchField() below
+        // pushes the cursor into the search field directly via the
+        // responder chain instead of relying on @FocusState.
         let panel = KeyCapturingPanel(
             contentRect: NSRect(x: 0, y: 0, width: 500, height: 430),
-            styleMask: [.borderless],
+            styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
@@ -134,7 +138,10 @@ class QuickPickerWindowManager: NSObject, ObservableObject, QuickPickerDelegate 
         panel.quickPickerDelegate = self
 
         panel.isFloatingPanel = true
-        panel.level = .floating  // Use floating level instead of screenSaver
+        // Keep .floating so QuickLook (which uses ~floating level) can render
+        // above the picker when the user previews an item. A higher level like
+        // .popUpMenu would shove QL behind the picker.
+        panel.level = .floating
         panel.backgroundColor = .clear
         panel.isOpaque = false
         panel.hasShadow = true
@@ -144,9 +151,11 @@ class QuickPickerWindowManager: NSObject, ObservableObject, QuickPickerDelegate 
         panel.worksWhenModal = true
         panel.isMovableByWindowBackground = true
         panel.isMovable = true
+        // canJoinAllSpaces + fullScreenAuxiliary lets the panel render on top
+        // of another app's fullscreen Space without triggering a Space switch.
         panel.collectionBehavior = [
             .canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle,
-            .transient  // Add transient to prevent it from becoming main
+            .transient
         ]
 
         // Create content view
@@ -188,36 +197,32 @@ class QuickPickerWindowManager: NSObject, ObservableObject, QuickPickerDelegate 
             panel.setFrameOrigin(origin)
         }
 
-        // Store current activation policy
-        let currentPolicy = NSApp.activationPolicy()
-        
-        // Temporarily set to accessory to prevent dock icon bounce
-        if currentPolicy == .regular {
-            NSApp.setActivationPolicy(.accessory)
-        }
-        
-        // Show panel without activating main app
+        // Show the panel and activate our app so it becomes the OS-level
+        // active app. macOS routes key events to the active app first, so
+        // without this the trigger key (space / →) for QuickLook leaks
+        // through to whichever app was frontmost before the picker opened
+        // and types the literal character there.
+        //
+        // We deliberately do NOT toggle activation policy
+        // (.regular ↔ .accessory) — that's what previously caused a Space
+        // switch out of another app's fullscreen Space. NSApp.activate by
+        // itself is safe here because the orderOut() loop above already
+        // hid every other window of ours, and the panel itself lives on the
+        // current Space (canJoinAllSpaces + fullScreenAuxiliary), so macOS
+        // has nothing to switch Spaces *to*.
         panel.orderFrontRegardless()
         panel.makeKey()
-        
-        // Activate the app to ensure we can receive keyboard events
         NSApp.activate(ignoringOtherApps: true)
-        
-        // Force keyboard focus to the panel
-        DispatchQueue.main.async {
-            panel.makeKey()
-            panel.makeMain()
-            if let contentView = panel.contentView {
-                panel.makeFirstResponder(contentView)
-                contentView.becomeFirstResponder()
-            }
-            
-            // Restore activation policy after a short delay
-            if currentPolicy == .regular {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    NSApp.setActivationPolicy(currentPolicy)
-                }
-            }
+
+        // Push the cursor straight into the search TextField. SwiftUI renders
+        // the TextField as an NSTextField inside the hosting view; we walk
+        // the subview tree to find it and make it first responder. The small
+        // delay lets SwiftUI finish its initial render so the NSTextField
+        // actually exists. Doing this via the AppKit responder chain works
+        // reliably even when @FocusState misfires (which it does inside a
+        // borderless .nonactivatingPanel).
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+            self?.focusSearchField()
         }
 
         self.window = panel
@@ -266,6 +271,11 @@ class QuickPickerWindowManager: NSObject, ObservableObject, QuickPickerDelegate 
 
         if isPreviewPanelVisible() {
             hidePreviewPanel()
+            // QLPreviewPanel.orderOut leaves first responder unset, so arrow
+            // keys / trigger key would do nothing in the picker afterwards.
+            // Re-key our panel so the search field regains the cursor and
+            // SwiftUI's onKeyPress handlers wake up again.
+            reclaimKeyFocus()
         } else {
             showPreviewPanel(for: item)
         }
@@ -284,6 +294,56 @@ class QuickPickerWindowManager: NSObject, ObservableObject, QuickPickerDelegate 
         case .disabled:
             break
         }
+        // Re-take key focus on our QuickPicker panel after showing the preview.
+        // QLPreviewPanel.makeKeyAndOrderFront steals key, and with
+        // .nonactivatingPanel our app is not "active", so without this the
+        // trigger key (space / →) and escape would be delivered to whichever
+        // app was frontmost before the picker opened — typing the literal
+        // character there instead of toggling the preview off.
+        reclaimKeyFocus()
+    }
+
+    private func reclaimKeyFocus() {
+        // Re-take key on our panel after QuickLook steals it and put the
+        // cursor back into the search field. Without this, arrow keys and
+        // the trigger key go nowhere after closing QL.
+        DispatchQueue.main.async { [weak self] in
+            guard let window = self?.window else { return }
+            window.makeKey()
+            self?.focusSearchField()
+        }
+    }
+
+    /// Walk the hosting view's subview tree to find the search NSTextField
+    /// (rendered by SwiftUI's TextField) and make it first responder so the
+    /// cursor lands in it. Falls back to the hosting view if no field is
+    /// found yet (rare — would mean SwiftUI hasn't rendered).
+    private func focusSearchField() {
+        guard let window = window, let contentView = window.contentView else { return }
+        if let textField = Self.findFirstTextField(in: contentView) {
+            window.makeFirstResponder(textField)
+        } else {
+            window.makeFirstResponder(contentView)
+        }
+    }
+
+    private static func findFirstTextField(in view: NSView) -> NSView? {
+        if view is NSTextField {
+            return view
+        }
+        // SwiftUI on macOS sometimes wraps text input in a private subclass
+        // whose class name contains "TextField" — match by name as a fallback
+        // so we don't miss it on future macOS versions.
+        let className = String(describing: type(of: view))
+        if className.contains("TextField"), view.acceptsFirstResponder {
+            return view
+        }
+        for subview in view.subviews {
+            if let found = findFirstTextField(in: subview) {
+                return found
+            }
+        }
+        return nil
     }
 
     private func updatePreviewPanel(for item: CBItem) {

--- a/StoneClipboarderTool/Manager/QuickPickerWindowManager.swift
+++ b/StoneClipboarderTool/Manager/QuickPickerWindowManager.swift
@@ -35,11 +35,11 @@ class KeyCapturingPanel: NSPanel {
     }
 
     override var canBecomeMain: Bool {
-        return true  // Allow it to become main to receive proper focus
+        return canBecomeKey  // Allow it to become main to receive proper focus
     }
 
     override var acceptsFirstResponder: Bool {
-        return true
+        return canBecomeKey
     }
 
     override func becomeFirstResponder() -> Bool {
@@ -51,10 +51,8 @@ class KeyCapturingPanel: NSPanel {
         super.sendEvent(event)
 
         // Force focus for any keyboard events
-        if event.type == .keyDown || event.type == .keyUp {
-            if !self.isKeyWindow {
-                self.makeKey()
-            }
+        if (event.type == .keyDown || event.type == .keyUp), !self.isKeyWindow {
+            self.makeKey()
         }
     }
 

--- a/StoneClipboarderTool/Manager/QuickPickerWindowManager.swift
+++ b/StoneClipboarderTool/Manager/QuickPickerWindowManager.swift
@@ -6,6 +6,7 @@
 //
 
 import AppKit
+import QuickLookUI
 import SwiftUI
 
 class QuickPickerHostingView: NSHostingView<QuickPickerView> {
@@ -81,6 +82,12 @@ class QuickPickerWindowManager: NSObject, ObservableObject, QuickPickerDelegate 
     private var isDragging = false
     private var dragOffset: NSPoint = NSPoint.zero
     private var menuBarRefreshCallback: (() -> Void)?
+    // Debounced dismiss used when QL panel is open — avoids frame-check fragility
+    // and double-scheduling when the user clicks twice on the QL panel.
+    nonisolated(unsafe) private var pendingQLDismiss: DispatchWorkItem?
+    // Observes app resign-active so QuickPicker closes when an external app activates
+    // (e.g. "Open with TextEdit" in QL, whether TextEdit was already running or not).
+    private var resignActiveObserver: NSObjectProtocol?
 
     func setCBViewModel(_ viewModel: CBViewModel) {
         self.cbViewModel = viewModel
@@ -219,9 +226,13 @@ class QuickPickerWindowManager: NSObject, ObservableObject, QuickPickerDelegate 
         setupEventMonitoring()
         setupKeyMonitoring()
         setupLocalKeyMonitoring()
+        setupResignActiveObserver()
     }
 
     func hideQuickPicker() {
+        pendingQLDismiss?.cancel()
+        pendingQLDismiss = nil
+        removeResignActiveObserver()
         hidePreviewPanel()
         removeEventMonitoring()
         removeKeyMonitoring()
@@ -314,9 +325,34 @@ class QuickPickerWindowManager: NSObject, ObservableObject, QuickPickerDelegate 
             else { return }
 
             let clickLocation = NSEvent.mouseLocation
-            if !window.frame.contains(clickLocation) {
-                self.hideQuickPicker()
+
+            // Never dismiss for clicks inside the QuickPicker window itself
+            if window.frame.contains(clickLocation) {
+                return
             }
+
+            // When native QL is visible, ANY click outside the QuickPicker could be on
+            // the QL panel body OR its detached toolbar/HUD ("Open with" button lives there).
+            // Frame-checking is unreliable because that button is in a separate NSWindow.
+            // Instead, debounce: cancel any previous pending dismiss and schedule a new one
+            // so the button's mouseUp action fires before we tear everything down.
+            if self.isPreviewPanelVisible() {
+                self.pendingQLDismiss?.cancel()
+                let work = DispatchWorkItem { [weak self] in
+                    self?.pendingQLDismiss = nil
+                    self?.hideQuickPicker()
+                }
+                self.pendingQLDismiss = work
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.8, execute: work)
+                return
+            }
+
+            // Don't dismiss for clicks inside the custom preview panel
+            if self.customPreviewManager.isPreviewVisible {
+                return
+            }
+
+            self.hideQuickPicker()
         }
     }
 
@@ -369,6 +405,40 @@ class QuickPickerWindowManager: NSObject, ObservableObject, QuickPickerDelegate 
         if let monitor = localKeyMonitor {
             NSEvent.removeMonitor(monitor)
             localKeyMonitor = nil
+        }
+    }
+
+    // MARK: - Resign Active Observer
+
+    private func setupResignActiveObserver() {
+        removeResignActiveObserver()
+        // Delay registration briefly so the NSApp.activate() call in showQuickPicker
+        // doesn't immediately fire the observer on app launch / re-show.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            guard let self = self else { return }
+            MainActor.assumeIsolated {
+                guard self.window?.isVisible == true else { return }
+                self.resignActiveObserver = NotificationCenter.default.addObserver(
+                    forName: NSApplication.willResignActiveNotification,
+                    object: nil,
+                    queue: .main
+                ) { [weak self] _ in
+                    MainActor.assumeIsolated {
+                        guard let self = self, self.window?.isVisible == true else { return }
+                        // Delay slightly so "Open with" button action fires and temp files survive
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                            self.hideQuickPicker()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func removeResignActiveObserver() {
+        if let observer = resignActiveObserver {
+            NotificationCenter.default.removeObserver(observer)
+            resignActiveObserver = nil
         }
     }
 

--- a/StoneClipboarderTool/Manager/QuickPickerWindowManager.swift
+++ b/StoneClipboarderTool/Manager/QuickPickerWindowManager.swift
@@ -282,7 +282,21 @@ class QuickPickerWindowManager: NSObject, ObservableObject, QuickPickerDelegate 
     }
 
     private func showPreviewPanel(for item: CBItem) {
-        let mode = settingsManager?.quickLookMode ?? .native
+        let configuredMode = settingsManager?.quickLookMode ?? .native
+        // QLPreviewPanel.shared() is system-managed and ignores the
+        // .canJoinAllSpaces / .fullScreenAuxiliary collection-behavior tweaks
+        // we'd need to render it in another app's fullscreen Space, so when
+        // the user is inside such a Space we transparently fall back to the
+        // custom preview (which uses an NSPanel we own and therefore *can*
+        // be shown over fullscreen content). Outside fullscreen, .native
+        // keeps using Apple's Quick Look as configured.
+        let mode: QuickLookMode
+        if configuredMode == .native && Self.isInOtherAppFullscreenSpace() {
+            mode = .custom
+        } else {
+            mode = configuredMode
+        }
+
         switch mode {
         case .native:
             guard quickLookCoordinator.prepareItem(item) else { return }
@@ -352,12 +366,12 @@ class QuickPickerWindowManager: NSObject, ObservableObject, QuickPickerDelegate 
     }
 
     func isPreviewPanelVisible() -> Bool {
-        let mode = settingsManager?.quickLookMode ?? .native
-        switch mode {
-        case .native: return quickLookCoordinator.isPreviewVisible
-        case .custom: return customPreviewManager.isPreviewVisible
-        case .disabled: return false
-        }
+        // Check both: when configured mode is .native but the user is in
+        // another app's fullscreen Space, showPreviewPanel transparently
+        // routes to the custom preview, so a strict mode-based switch would
+        // miss it and toggle/escape would think nothing is open.
+        guard settingsManager?.quickLookMode != .disabled else { return false }
+        return quickLookCoordinator.isPreviewVisible || customPreviewManager.isPreviewVisible
     }
 
     func hidePreviewPanel() {
@@ -544,5 +558,63 @@ class QuickPickerWindowManager: NSObject, ObservableObject, QuickPickerDelegate 
         if let monitor = localKeyMonitor {
             NSEvent.removeMonitor(monitor)
         }
+    }
+
+    // MARK: - Fullscreen Detection
+
+    /// True when the user is currently inside another app's native macOS
+    /// fullscreen Space. We detect this by scanning on-screen windows that
+    /// don't belong to us and checking whether any of them covers an entire
+    /// screen — that's the signature of a fullscreen Space (in regular
+    /// Spaces no app's window matches the screen frame exactly).
+    ///
+    /// Used to fall back from Apple's QLPreviewPanel (which is system-managed
+    /// and refuses to render in another app's fullscreen Space) to our own
+    /// custom preview panel, which is configured to render anywhere.
+    static func isInOtherAppFullscreenSpace() -> Bool {
+        guard let mainScreen = NSScreen.main else { return false }
+        let ourPID = ProcessInfo.processInfo.processIdentifier
+
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
+            return false
+        }
+
+        for window in windows {
+            // Skip our own windows (the QuickPicker panel itself can be
+            // borderless and on the same Space, but it doesn't span the
+            // screen — still, exclude defensively).
+            if let pid = window[kCGWindowOwnerPID as String] as? pid_t, pid == ourPID {
+                continue
+            }
+            // Only look at normal-layer windows; menu bar, dock, status
+            // items, etc. live on higher layers and would falsely match.
+            if let layer = window[kCGWindowLayer as String] as? Int, layer != 0 {
+                continue
+            }
+            guard let bounds = window[kCGWindowBounds as String] as? [String: CGFloat] else {
+                continue
+            }
+            let rect = CGRect(
+                x: bounds["X"] ?? 0,
+                y: bounds["Y"] ?? 0,
+                width: bounds["Width"] ?? 0,
+                height: bounds["Height"] ?? 0
+            )
+            for screen in NSScreen.screens {
+                if abs(rect.width - screen.frame.width) < 2,
+                   abs(rect.height - screen.frame.height) < 2 {
+                    return true
+                }
+            }
+            // Some apps (e.g. browsers) report fullscreen as the visibleFrame
+            // of mainScreen (excluding menu bar) — treat that as fullscreen
+            // too if menu bar is currently auto-hidden.
+            if abs(rect.width - mainScreen.frame.width) < 2,
+               abs(rect.height - mainScreen.visibleFrame.height) < 2 {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/StoneClipboarderTool/Model/CBItem.swift
+++ b/StoneClipboarderTool/Model/CBItem.swift
@@ -107,34 +107,32 @@ final class CBItem {
         }
 
         // Generate thumbnail on-demand for images and combined items
-        if itemType == .image || itemType == .combined {
-            if let imageData = imageData,
-                let image = NSImage(data: imageData)
+        if (itemType == .image || itemType == .combined),
+           let imageData = imageData,
+           let image = NSImage(data: imageData)
+        {
+            let thumbnail = generateThumbnailImage(from: image)
+            // Cache the generated thumbnail immediately
+            if let thumbnail = thumbnail,
+                let pngData = thumbnail.pngRepresentation
             {
-                let thumbnail = generateThumbnailImage(from: image)
-                // Cache the generated thumbnail immediately
-                if let thumbnail = thumbnail,
-                    let pngData = thumbnail.pngRepresentation
-                {
-                    self.thumbnailData = pngData
-                }
-                return thumbnail ?? createPlaceholderThumbnail()
+                self.thumbnailData = pngData
             }
+            return thumbnail ?? createPlaceholderThumbnail()
         }
         // Generate thumbnail for image files
-        else if isImageFile {
-            if let fileData = fileData,
+        else if isImageFile,
+                let fileData = fileData,
                 let image = NSImage(data: fileData)
+        {
+            let thumbnail = generateThumbnailImage(from: image)
+            // Cache the generated thumbnail immediately
+            if let thumbnail = thumbnail,
+                let pngData = thumbnail.pngRepresentation
             {
-                let thumbnail = generateThumbnailImage(from: image)
-                // Cache the generated thumbnail immediately
-                if let thumbnail = thumbnail,
-                    let pngData = thumbnail.pngRepresentation
-                {
-                    self.thumbnailData = pngData
-                }
-                return thumbnail ?? createPlaceholderThumbnail()
+                self.thumbnailData = pngData
             }
+            return thumbnail ?? createPlaceholderThumbnail()
         }
 
         // Return placeholder for failed generation

--- a/StoneClipboarderTool/View/Cells/BarNavigationCellView.swift
+++ b/StoneClipboarderTool/View/Cells/BarNavigationCellView.swift
@@ -33,14 +33,13 @@ struct BarNavigationCellView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            if item.itemType == .image || item.itemType == .combined || (item.itemType == .file && item.isImageFile) {
-                if let thumbnail = item.thumbnail {
-                    Image(nsImage: thumbnail)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .frame(maxWidth: 40, maxHeight: 30)
-                        .clipShape(RoundedRectangle(cornerRadius: 6))
-                }
+            if (item.itemType == .image || item.itemType == .combined || (item.itemType == .file && item.isImageFile)),
+               let thumbnail = item.thumbnail {
+                Image(nsImage: thumbnail)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(maxWidth: 40, maxHeight: 30)
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
             }
         }
         .padding(.horizontal, 8)

--- a/StoneClipboarderTool/View/Components/ClipboardAlerts.swift
+++ b/StoneClipboarderTool/View/Components/ClipboardAlerts.swift
@@ -34,7 +34,7 @@ struct ClipboardAlertModifier: ViewModifier {
                     set: { if !$0 { activeAlert = nil } }
                 )
             ) {
-                Button("Cancel", role: .cancel) {}
+                Button("Cancel", role: .cancel) { /* No action needed for cancel */ }
                 switch activeAlert {
                 case .cleanup:
                     Button("Clean Up", role: .destructive) {
@@ -105,10 +105,9 @@ enum AccessibilityAlertHelper {
 
             alert.window.level = .floating
 
-            if alert.runModal() == .alertFirstButtonReturn {
-                if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
-                    NSWorkspace.shared.open(url)
-                }
+            if alert.runModal() == .alertFirstButtonReturn,
+               let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
+                NSWorkspace.shared.open(url)
             }
         }
     }

--- a/StoneClipboarderTool/View/Components/SwipeableRow.swift
+++ b/StoneClipboarderTool/View/Components/SwipeableRow.swift
@@ -160,6 +160,16 @@ struct SwipeableRow<Content: View>: View {
             return false
         }
     }
+    
+    private var backgroundColor: Color {
+        if swipeOffset < -50 {
+            return Color.red.opacity(0.1)
+        } else if swipeOffset > 50 {
+            return Color.green.opacity(0.1)
+        } else {
+            return Color.clear
+        }
+    }
 
     init(@ViewBuilder content: () -> Content, onDelete: @escaping () -> Void) {
         self.content = content()
@@ -191,11 +201,7 @@ struct SwipeableRow<Content: View>: View {
                 .offset(x: swipeOffset)
                 .background(
                     Rectangle()
-                        .fill(
-                            swipeOffset < -50 ? Color.red.opacity(0.1) :
-                            swipeOffset > 50 ? Color.green.opacity(0.1) :
-                            Color.clear
-                        )
+                        .fill(backgroundColor)
                         .animation(.easeOut(duration: 0.1), value: swipeOffset)
                 )
                 .scaleEffect(isDeleting ? 0.95 : 1.0)

--- a/StoneClipboarderTool/View/ContentView.swift
+++ b/StoneClipboarderTool/View/ContentView.swift
@@ -128,7 +128,7 @@ struct ContentView: View {
                     }
                 }
             }
-            .clipboardAlert($activeAlert, onCleanup: {}, onDeleteAll: {
+            .clipboardAlert($activeAlert, onCleanup: { /* Cleanup not used in this context */ }, onDeleteAll: {
                 deleteAllItems()
             })
         } detail: {

--- a/StoneClipboarderTool/View/Menu/MenuBarItemView.swift
+++ b/StoneClipboarderTool/View/Menu/MenuBarItemView.swift
@@ -22,21 +22,18 @@ struct MenuBarItemView: View {
                     .font(.system(.body, design: .monospaced))
                     .lineLimit(2)
                     .foregroundStyle(.primary)
-                if item.itemType != .text {
-                    if let thumbnail = item.thumbnail {
-                        Image(nsImage: thumbnail)
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(maxHeight: 100)
-                            .cornerRadius(4)
-                    } else if item.itemType == .file && !item.isImageFile, let fileIcon = item.fileIcon
-                    {
-                        Image(nsImage: fileIcon)
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(maxHeight: 36)
-                            .cornerRadius(4)
-                    }
+                if item.itemType != .text, let thumbnail = item.thumbnail {
+                    Image(nsImage: thumbnail)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxHeight: 100)
+                        .cornerRadius(4)
+                } else if item.itemType == .file && !item.isImageFile, let fileIcon = item.fileIcon {
+                    Image(nsImage: fileIcon)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxHeight: 36)
+                        .cornerRadius(4)
                 }
 
                 Text(item.timestamp, format: Date.FormatStyle(date: .omitted, time: .shortened))

--- a/StoneClipboarderTool/View/QuickPicker/QPCustomPreviewPanel.swift
+++ b/StoneClipboarderTool/View/QuickPicker/QPCustomPreviewPanel.swift
@@ -215,10 +215,9 @@ class QPCustomPreviewManager {
             let mainFrame = mainWindow.frame
             var origin = NSPoint(x: mainFrame.maxX + 8, y: mainFrame.origin.y)
 
-            if let screen = NSScreen.main {
-                if origin.x + 420 > screen.visibleFrame.maxX {
-                    origin.x = mainFrame.minX - 420 - 8
-                }
+            if let screen = NSScreen.main,
+               origin.x + 420 > screen.visibleFrame.maxX {
+                origin.x = mainFrame.minX - 420 - 8
             }
             panel.setFrameOrigin(origin)
         }

--- a/StoneClipboarderTool/View/QuickPicker/QPCustomPreviewPanel.swift
+++ b/StoneClipboarderTool/View/QuickPicker/QPCustomPreviewPanel.swift
@@ -192,9 +192,14 @@ class QPCustomPreviewManager {
             return
         }
 
+        // .nonactivatingPanel is required so the preview can render alongside
+        // another app's fullscreen Space without forcing a Space switch — the
+        // QuickPicker panel uses the same flag for the same reason. Without
+        // it, an activating borderless panel resolves to our app's home
+        // Space instead of the user's current fullscreen Space.
         let panel = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: 420, height: 400),
-            styleMask: [.borderless],
+            styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )

--- a/StoneClipboarderTool/View/QuickPicker/QPItemList.swift
+++ b/StoneClipboarderTool/View/QuickPicker/QPItemList.swift
@@ -181,8 +181,8 @@ struct QPItemList: View {
         searchText: .constant(""),
         isLoading: false,
         hasMoreItems: true,
-        onLoadMore: {},
-        performAction: {},
+        onLoadMore: { /* preview dummy implementation */ },
+        performAction: { /* preview dummy implementation */ },
         onOpenPreview: { _ in },
         onOpenTextEdit: { _ in }
     )

--- a/StoneClipboarderTool/View/QuickPicker/QPQuickLookCoordinator.swift
+++ b/StoneClipboarderTool/View/QuickPicker/QPQuickLookCoordinator.swift
@@ -121,13 +121,23 @@ class QPQuickLookCoordinator: NSObject, QLPreviewPanelDataSource, QLPreviewPanel
     }
 
     /// Hide the QLPreviewPanel if visible.
+    /// Delays temp file cleanup so "Open with" actions can read the file.
     func hidePreview() {
         if QLPreviewPanel.sharedPreviewPanelExists(),
            let panel = QLPreviewPanel.shared(),
            panel.isVisible {
             panel.orderOut(nil)
         }
-        cleanupTempFiles()
+
+        // Delay cleanup so external apps launched via "Open with" have time to read the file
+        let tempDir = tempDirectory
+        tempDirectory = nil
+        previewURL = nil
+        if let tempDir = tempDir {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+                try? FileManager.default.removeItem(at: tempDir)
+            }
+        }
     }
 
     /// Whether the preview panel is currently visible.

--- a/StoneClipboarderTool/View/QuickPicker/QPQuickLookCoordinator.swift
+++ b/StoneClipboarderTool/View/QuickPicker/QPQuickLookCoordinator.swift
@@ -122,11 +122,10 @@ class QPQuickLookCoordinator: NSObject, QLPreviewPanelDataSource, QLPreviewPanel
 
     /// Hide the QLPreviewPanel if visible.
     func hidePreview() {
-        if QLPreviewPanel.sharedPreviewPanelExists() {
-            let panel = QLPreviewPanel.shared()!
-            if panel.isVisible {
-                panel.orderOut(nil)
-            }
+        if QLPreviewPanel.sharedPreviewPanelExists(),
+           let panel = QLPreviewPanel.shared(),
+           panel.isVisible {
+            panel.orderOut(nil)
         }
         cleanupTempFiles()
     }
@@ -139,13 +138,13 @@ class QPQuickLookCoordinator: NSObject, QLPreviewPanelDataSource, QLPreviewPanel
 
     // MARK: - QLPreviewPanelDataSource
 
-    nonisolated func numberOfPreviewItems(in panel: QLPreviewPanel!) -> Int {
+    nonisolated func numberOfPreviewItems(in _: QLPreviewPanel!) -> Int {
         return MainActor.assumeIsolated {
             previewURL != nil ? 1 : 0
         }
     }
 
-    nonisolated func previewPanel(_ panel: QLPreviewPanel!, previewItemAt index: Int) -> (any QLPreviewItem)! {
+    nonisolated func previewPanel(_: QLPreviewPanel!, previewItemAt _: Int) -> (any QLPreviewItem)! {
         return MainActor.assumeIsolated {
             previewURL as? QLPreviewItem
         }

--- a/StoneClipboarderTool/View/QuickPicker/QuickPickerView.swift
+++ b/StoneClipboarderTool/View/QuickPicker/QuickPickerView.swift
@@ -108,13 +108,12 @@ struct QuickPickerView: View {
             .onKeyPress(.rightArrow) {
                 guard triggerKey == .arrowRight else { return .ignored }
                 // Only open QL when cursor is at the end of search text
-                if isSearchFocused && !searchText.isEmpty {
-                    if let fieldEditor = NSApp.keyWindow?.firstResponder as? NSTextView {
-                        let sel = fieldEditor.selectedRange()
-                        let cursorEnd = sel.location + sel.length
-                        if cursorEnd < fieldEditor.string.count {
-                            return .ignored // Let cursor move normally
-                        }
+                if isSearchFocused && !searchText.isEmpty,
+                   let fieldEditor = NSApp.keyWindow?.firstResponder as? NSTextView {
+                    let sel = fieldEditor.selectedRange()
+                    let cursorEnd = sel.location + sel.length
+                    if cursorEnd < fieldEditor.string.count {
+                        return .ignored // Let cursor move normally
                     }
                 }
                 return handlePreviewTrigger()

--- a/StoneClipboarderTool/View/Settings/ExcludedAppsSettingsView.swift
+++ b/StoneClipboarderTool/View/Settings/ExcludedAppsSettingsView.swift
@@ -320,7 +320,7 @@ struct AppPickerView: View {
                     onAppRemoved(excludedApp)
                 }
             }
-            Button("Cancel", role: .cancel) {}
+            Button("Cancel", role: .cancel) { /* No action needed for cancel */ }
         } message: { app in
             Text("'\(app.name)' is already in the excluded apps list. Do you want to remove it?")
         }

--- a/StoneClipboarderTool/View/Settings/HotkeySettingsView.swift
+++ b/StoneClipboarderTool/View/Settings/HotkeySettingsView.swift
@@ -72,7 +72,7 @@ struct HotkeySettingsView: View {
         .formStyle(.grouped)
         .navigationTitle("Hotkey Settings")
         .alert("Hotkey Conflict", isPresented: $showingConflictAlert) {
-            Button("OK") {}
+            Button("OK") { /* No action needed for acknowledgement */ }
         } message: {
             Text(conflictMessage)
         }
@@ -140,6 +140,12 @@ struct HotkeyConfigRow: View {
     @State private var globalEventMonitor: Any?
     @State private var blockedShortcut = ""
 
+    private var rowOpacity: Double {
+        let recordingOther = currentlyRecordingID != nil && currentlyRecordingID != config.id
+        let dimmedForRecording = recordingOther ? 0.4 : 1.0
+        return settingsManager.enableHotkeys ? dimmedForRecording : 0.6
+    }
+
     var body: some View {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
@@ -198,12 +204,7 @@ struct HotkeyConfigRow: View {
                 !settingsManager.enableHotkeys
                     || (currentlyRecordingID != nil && currentlyRecordingID != config.id))
         }
-        .opacity(
-            settingsManager.enableHotkeys
-                ? (currentlyRecordingID != nil && currentlyRecordingID != config.id ? 0.4 : 1.0)
-                : 0.6
-        )
-        .animation(.easeInOut(duration: 0.2), value: currentlyRecordingID)
+        .opacity(rowOpacity)
         .onDisappear {
             stopRecording()
         }
@@ -215,36 +216,34 @@ struct HotkeyConfigRow: View {
     }
 
     private var displayText: String {
-        if isRecording {
-            if !blockedShortcut.isEmpty {
-                return "\(blockedShortcut) (blocked)"
-            } else if recordedShortcut.isEmpty {
-                return "Press keys..."
-            } else {
-                // Show preview with first character highlighted
-                let modifierChars: Set<Character> = ["⌃", "⌥", "⇧", "⌘"]
-                let modifiers = String(recordedShortcut.filter { modifierChars.contains($0) })
-                let keys = String(recordedShortcut.filter { !modifierChars.contains($0) })
-                if !keys.isEmpty {
-                    let firstChar = String(keys.prefix(1))
-                    return "\(modifiers)\(firstChar)..."
-                } else {
-                    return recordedShortcut
-                }
-            }
-        } else {
+        guard isRecording else {
             let shortcut = config.shortcutKeys ?? ""
             return shortcut.isEmpty ? "None" : shortcut
+        }
+        
+        if !blockedShortcut.isEmpty {
+            return "\(blockedShortcut) (blocked)"
+        } else if recordedShortcut.isEmpty {
+            return "Press keys..."
+        } else {
+            // Show preview with first character highlighted
+            let modifierChars: Set<Character> = ["⌃", "⌥", "⇧", "⌘"]
+            let modifiers = String(recordedShortcut.filter { modifierChars.contains($0) })
+            let keys = String(recordedShortcut.filter { !modifierChars.contains($0) })
+            if !keys.isEmpty {
+                let firstChar = String(keys.prefix(1))
+                return "\(modifiers)\(firstChar)..."
+            } else {
+                return recordedShortcut
+            }
         }
     }
 
     private var backgroundColor: Color {
-        if isRecording {
-            if !blockedShortcut.isEmpty {
-                return Color.red.opacity(0.3)
-            } else {
-                return Color.accentColor.opacity(0.3)
-            }
+        if isRecording, !blockedShortcut.isEmpty {
+            return Color.red.opacity(0.3)
+        } else if isRecording {
+            return Color.accentColor.opacity(0.3)
         } else if currentlyRecordingID != nil && currentlyRecordingID != config.id {
             return Color.gray.opacity(0.05)
         } else {
@@ -361,59 +360,26 @@ struct HotkeyConfigRow: View {
     }
 
     private func keyStringForKeyCode(_ keyCode: UInt16) -> String? {
-
-        switch keyCode {
-        case 18: return "1"
-        case 19: return "2"
-        case 20: return "3"
-        case 21: return "4"
-        case 23: return "5"
-        case 22: return "6"
-        case 26: return "7"
-        case 28: return "8"
-        case 25: return "9"
-        case 29: return "0"
-        case 49: return "Space"
-        case 0: return "A"
-        case 11: return "B"
-        case 8: return "C"
-        case 2: return "D"
-        case 14: return "E"
-        case 3: return "F"
-        case 5: return "G"
-        case 4: return "H"
-        case 34: return "I"
-        case 38: return "J"
-        case 40: return "K"
-        case 37: return "L"
-        case 46: return "M"
-        case 45: return "N"
-        case 31: return "O"
-        case 35: return "P"
-        case 12: return "Q"
-        case 15: return "R"
-        case 1: return "S"
-        case 17: return "T"
-        case 32: return "U"
-        case 9: return "V"
-        case 13: return "W"
-        case 7: return "X"
-        case 16: return "Y"
-        case 6: return "Z"
-        case 36: return "Return"
-        case 53: return "Escape"
-        case 51: return "Delete"
-        case 48: return "Tab"
-        case 76: return "Enter"
-        case 123: return "←"
-        case 124: return "→"
-        case 125: return "↓"
-        case 126: return "↑"
-        default:
-
-            // Fallback: try to get character from key code
-            return getCharacterFromKeyCode(keyCode)
+        // Static lookup table mapping key codes to display strings
+        let keyCodeMap: [UInt16: String] = [
+            18: "1", 19: "2", 20: "3", 21: "4", 23: "5",
+            22: "6", 26: "7", 28: "8", 25: "9", 29: "0",
+            49: "Space",
+            0: "A",  11: "B", 8: "C",  2: "D",  14: "E",
+            3: "F",  5: "G",  4: "H",  34: "I", 38: "J",
+            40: "K", 37: "L", 46: "M", 45: "N", 31: "O",
+            35: "P", 12: "Q", 15: "R", 1: "S",  17: "T",
+            32: "U", 9: "V",  13: "W", 7: "X",  16: "Y",
+            6: "Z",
+            36: "Return", 53: "Escape", 51: "Delete",
+            48: "Tab",    76: "Enter",
+            123: "←",    124: "→",    125: "↓",  126: "↑",
+        ]
+        if let mapped = keyCodeMap[keyCode] {
+            return mapped
         }
+        // Fallback: try to get character from key code
+        return getCharacterFromKeyCode(keyCode)
     }
 
     private func getCharacterFromKeyCode(_ keyCode: UInt16) -> String? {

--- a/StoneClipboarderTool/View/Settings/SettingsView.swift
+++ b/StoneClipboarderTool/View/Settings/SettingsView.swift
@@ -59,7 +59,7 @@ struct SettingsView: View {
             Button("Enable") {
                 settingsManager.startAtLogin = true
             }
-            Button("Not Now", role: .cancel) {}
+            Button("Not Now", role: .cancel) { /* No action needed for cancel */ }
         } message: {
             Text("Would you like StoneClipboarder to start automatically when you log in?\n\nYou can change this later in Settings > Accessibility or in macOS System Settings > Login Items.")
         }

--- a/StoneClipboarderTool/View/Small/ActionsBottomButtonView.swift
+++ b/StoneClipboarderTool/View/Small/ActionsBottomButtonView.swift
@@ -69,25 +69,23 @@ struct ActionsBottomButtonView: View {
                 .buttonStyle(.bordered)
             }
 
-            if item.itemType == .text {
-                if isEditing {
-                    Button("Save Changes") {
-                        saveTextChanges()
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(!hasChanges)
-                    
-                    Button("Cancel") {
-                        cancelEditing()
-                    }
-                    .buttonStyle(.bordered)
-                } else {
-                    // TODO: if it is link add "Open Link" button
-                    Button("Edit Text") {
-                        startEditing()
-                    }
-                    .buttonStyle(.bordered)
+            if item.itemType == .text, isEditing {
+                Button("Save Changes") {
+                    saveTextChanges()
                 }
+                .buttonStyle(.borderedProminent)
+                .disabled(!hasChanges)
+                
+                Button("Cancel") {
+                    cancelEditing()
+                }
+                .buttonStyle(.bordered)
+            } else if item.itemType == .text {
+                // TODO: if it is link add "Open Link" button
+                Button("Edit Text") {
+                    startEditing()
+                }
+                .buttonStyle(.bordered)
             }
             
             Spacer()

--- a/StoneClipboarderTool/View/ZoomView/ZoomableDetailView.swift
+++ b/StoneClipboarderTool/View/ZoomView/ZoomableDetailView.swift
@@ -344,20 +344,19 @@ struct ZoomableDetailView: View {
         savePanel.nameFieldStringValue = "clipboard_image"
         
         savePanel.begin { result in
-            if result == .OK, let url = savePanel.url {
-                if let tiffData = image.tiffRepresentation,
-                   let bitmapRep = NSBitmapImageRep(data: tiffData) {
-                    
-                    let imageData: Data?
-                    if url.pathExtension.lowercased() == "png" {
-                        imageData = bitmapRep.representation(using: .png, properties: [:])
-                    } else {
-                        imageData = bitmapRep.representation(using: .jpeg, properties: [.compressionFactor: 0.9])
-                    }
-                    
-                    if let data = imageData {
-                        try? data.write(to: url)
-                    }
+            if result == .OK, let url = savePanel.url,
+               let tiffData = image.tiffRepresentation,
+               let bitmapRep = NSBitmapImageRep(data: tiffData) {
+
+                let imageData: Data?
+                if url.pathExtension.lowercased() == "png" {
+                    imageData = bitmapRep.representation(using: .png, properties: [:])
+                } else {
+                    imageData = bitmapRep.representation(using: .jpeg, properties: [.compressionFactor: 0.9])
+                }
+
+                if let data = imageData {
+                    try? data.write(to: url)
                 }
             }
         }

--- a/StoneClipboarderTool/ViewModel/CBViewModel.swift
+++ b/StoneClipboarderTool/ViewModel/CBViewModel.swift
@@ -668,10 +668,9 @@ class CBViewModel: ObservableObject {
                 continue
             }
 
-            if let lastAccess = lastAccessTimes[item.persistentModelID] {
-                if now.timeIntervalSince(lastAccess) > maxInactiveTime {
-                    itemsToCleanup.append(item)
-                }
+            if let lastAccess = lastAccessTimes[item.persistentModelID],
+               now.timeIntervalSince(lastAccess) > maxInactiveTime {
+                itemsToCleanup.append(item)
             }
         }
 

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -11,12 +11,42 @@
         <language>en</language>
 
     <item>
+        <title>Version VERSION_NUMBER</title>
+        <link>https://REPO_OWNER.github.io/REPO_NAME/</link>
+        <sparkle:version>VERSION_NUMBER</sparkle:version>
+        <sparkle:shortVersionString>VERSION_NUMBER</sparkle:shortVersionString>
+        <description
+            ><![CDATA[
+            <h2>StoneClipboarderTool VERSION_NUMBER</h2>
+            <ul>
+                <li>🪟 NEW: Quick Picker now renders over other apps' fullscreen Spaces — open it without leaving the app you're in</li>
+                <li>🖼️ NEW: Menu bar popover now appears alongside other apps' fullscreen apps too</li>
+                <li>🔍 NEW: Smart preview fallback — when you trigger preview while in another app's fullscreen Space, the custom preview is used automatically (Apple Quick Look is system-managed and can't render in another app's fullscreen)</li>
+                <li>⌨️ IMPROVED: Search field cursor now lands in the Quick Picker on open and is restored after closing the preview</li>
+                <li>🛠️ FIXED: Quick Picker no longer pulls you out of another app's fullscreen Space when triggered</li>
+                <li>🛠️ FIXED: QuickLook stability — temp files are cleaned up with a delay so "Open with…" actions have time to read them</li>
+                <li>🛠️ IMPROVED: Window resignation handling — Quick Picker now closes cleanly when an external app activates (e.g. via "Open with…")</li>
+                <li>🧹 IMPROVED: Code quality refactor based on SonarCloud scanner issues</li>
+            </ul>
+        ]]></description>
+        <pubDate>RELEASE_DATE</pubDate>
+        <enclosure
+                url="https://github.com/REPO_OWNER/REPO_NAME/releases/download/vVERSION_NUMBER/StoneClipboarderTool.zip"
+                sparkle:version="VERSION_NUMBER"
+                sparkle:shortVersionString="VERSION_NUMBER"
+                sparkle:edSignature="SIGNATURE_PLACEHOLDER"
+                length="FILE_SIZE"
+                type="application/octet-stream"
+            />
+    </item>
+    
+    <item>
         <title>Version 1.5.2</title>
         <link>https://foxfollow.github.io/Stone-Clipboarder-Tool/</link>
         <sparkle:version>14</sparkle:version>
         <sparkle:shortVersionString>1.5.2</sparkle:shortVersionString>
         <description
-        ><![CDATA[
+            ><![CDATA[
             <h2>StoneClipboarderTool 1.5.2</h2>
             <ul>
                 <li>🛡️ NEW: Accessibility settings tab — view permission status and open System Settings directly</li>
@@ -32,13 +62,13 @@
         ]]></description>
         <pubDate>Fri, 20 Mar 2026 13:29:52 +0000</pubDate>
         <enclosure
-            url="https://github.com/foxfollow/Stone-Clipboarder-Tool/releases/download/v1.5.2/StoneClipboarderTool.zip"
-            sparkle:version="14"
-            sparkle:shortVersionString="1.5.2"
-            sparkle:edSignature="op7hyVkCIt0JMbYiLRDi6sip3Is19/If3W9S5DvKQ2VWoHVJgiw261gRyKgW1Ix69jLQp3itFh2li3lD+NOKBA=="
-            length="4525426"
-            type="application/octet-stream"
-        />
+                url="https://github.com/foxfollow/Stone-Clipboarder-Tool/releases/download/v1.5.2/StoneClipboarderTool.zip"
+                sparkle:version="14"
+                sparkle:shortVersionString="1.5.2"
+                sparkle:edSignature="op7hyVkCIt0JMbYiLRDi6sip3Is19/If3W9S5DvKQ2VWoHVJgiw261gRyKgW1Ix69jLQp3itFh2li3lD+NOKBA=="
+                length="4525426"
+                type="application/octet-stream"
+            />
     </item>
 
     <item>
@@ -47,19 +77,19 @@
         <sparkle:version>13</sparkle:version>
         <sparkle:shortVersionString>1.4.0</sparkle:shortVersionString>
         <description
-        ><![CDATA[
+            ><![CDATA[
             <h2>Version 1.4.0</h2>
             <p>See release notes on GitHub for details.</p>
         ]]></description>
         <pubDate>Mon, 16 Feb 2026 14:32:00 +0000</pubDate>
         <enclosure
-            url="https://github.com/foxfollow/Stone-Clipboarder-Tool/releases/download/v1.4.0/StoneClipboarderTool.zip"
-            sparkle:version="13"
-            sparkle:shortVersionString="1.4.0"
-            sparkle:edSignature="zfo2vhXZC55I/XiJIafed+WAFREv/3eHfWi9pn/MQ/xlFhOpDpK5xxvAV7EK+SD3DdAs3WyK51OxXRveCABvBQ=="
-            length="4417177"
-            type="application/octet-stream"
-        />
+                url="https://github.com/foxfollow/Stone-Clipboarder-Tool/releases/download/v1.4.0/StoneClipboarderTool.zip"
+                sparkle:version="13"
+                sparkle:shortVersionString="1.4.0"
+                sparkle:edSignature="zfo2vhXZC55I/XiJIafed+WAFREv/3eHfWi9pn/MQ/xlFhOpDpK5xxvAV7EK+SD3DdAs3WyK51OxXRveCABvBQ=="
+                length="4417177"
+                type="application/octet-stream"
+            />
     </item>
 
     <item>
@@ -68,7 +98,7 @@
         <sparkle:version>1.4.0</sparkle:version>
         <sparkle:shortVersionString>1.4.0</sparkle:shortVersionString>
         <description
-        ><![CDATA[
+            ><![CDATA[
             <h2>StoneClipboarderTool 1.4.0</h2>
             <ul>
                 <li>🛡️ Separated database storage for clipboard history and settings — corruption in one won't affect the other</li>
@@ -88,13 +118,13 @@
         ]]></description>
         <pubDate>RELEASE_DATE</pubDate>
         <enclosure
-            url="https://github.com/foxfollow/Stone-Clipboarder-Tool/releases/download/v1.4.0/StoneClipboarderTool.zip"
-            sparkle:version="1.4.0"
-            sparkle:shortVersionString="1.4.0"
-            sparkle:edSignature="SIGNATURE_PLACEHOLDER"
-            length="FILE_SIZE"
-            type="application/octet-stream"
-        />
+                url="https://github.com/foxfollow/Stone-Clipboarder-Tool/releases/download/v1.4.0/StoneClipboarderTool.zip"
+                sparkle:version="1.4.0"
+                sparkle:shortVersionString="1.4.0"
+                sparkle:edSignature="SIGNATURE_PLACEHOLDER"
+                length="FILE_SIZE"
+                type="application/octet-stream"
+            />
     </item>
 
     <item>
@@ -103,7 +133,7 @@
         <sparkle:version>12</sparkle:version>
         <sparkle:shortVersionString>1.3.2</sparkle:shortVersionString>
         <description
-        ><![CDATA[
+            ><![CDATA[
             <h2>Version 1.3.2</h2>
             <ul>
 <li>✨ IMPROVED: Quick Picker now asks Accessibility for pasting simulation</li>
@@ -113,13 +143,13 @@
         ]]></description>
         <pubDate>Sat, 27 Dec 2025 19:32:19 +0000</pubDate>
         <enclosure
-            url="https://github.com/foxfollow/Stone-Clipboarder-Tool/releases/download/v1.3.2/StoneClipboarderTool.zip"
-            sparkle:version="12"
-            sparkle:shortVersionString="1.3.2"
-            sparkle:edSignature="gApidUbsszK3qCToD7ljStKhS4xWnAlQYUG4AyDG/QobwmaV4Y01GQ8eCuoYo1OLu/hAvsVoB4KHEzzVeuRmCg=="
-            length="4198731"
-            type="application/octet-stream"
-        />
+                url="https://github.com/foxfollow/Stone-Clipboarder-Tool/releases/download/v1.3.2/StoneClipboarderTool.zip"
+                sparkle:version="12"
+                sparkle:shortVersionString="1.3.2"
+                sparkle:edSignature="gApidUbsszK3qCToD7ljStKhS4xWnAlQYUG4AyDG/QobwmaV4Y01GQ8eCuoYo1OLu/hAvsVoB4KHEzzVeuRmCg=="
+                length="4198731"
+                type="application/octet-stream"
+            />
     </item>
 
 

--- a/docs/version-history.html
+++ b/docs/version-history.html
@@ -109,9 +109,27 @@
         <!-- Version List -->
         <section class="max-w-3xl mx-auto px-4 space-y-8">
 
-            <!-- Version 1.5.2 -->
+            <!-- Version 1.5.3 -->
             <div class="card-gradient rounded-2xl p-8 relative">
                 <span class="absolute top-6 right-6 inline-flex items-center px-3 py-1 rounded-full text-xs font-bold bg-green-500/20 text-green-400 border border-green-500/30">Latest</span>
+                <div class="flex items-baseline gap-4 mb-4 border-b border-white/5 pb-4">
+                    <h3 class="font-mono text-2xl font-bold text-white">Version 1.5.3</h3>
+                    <span class="version-date text-sm text-gray-500">Apr 2026</span>
+                </div>
+                <ul class="space-y-3 text-gray-300 text-sm leading-relaxed list-none pl-0">
+                    <li>🪟 <strong>NEW:</strong> Quick Picker now renders over other apps' fullscreen Spaces — open it without leaving the app you're in</li>
+                    <li>🖼️ <strong>NEW:</strong> Menu bar popover now appears alongside other apps' fullscreen apps too</li>
+                    <li>🔍 <strong>NEW:</strong> Smart preview fallback — when you trigger preview while in another app's fullscreen Space, the custom preview is used automatically (Apple Quick Look is system-managed and can't render in another app's fullscreen)</li>
+                    <li>⌨️ <strong>IMPROVED:</strong> Search field cursor now lands in the Quick Picker on open and is restored after closing the preview</li>
+                    <li>🛠️ <strong>FIXED:</strong> Quick Picker no longer pulls you out of another app's fullscreen Space when triggered</li>
+                    <li>🛠️ <strong>FIXED:</strong> QuickLook stability — temp files are cleaned up with a delay so "Open with…" actions have time to read them</li>
+                    <li>🛠️ <strong>IMPROVED:</strong> Window resignation handling — Quick Picker now closes cleanly when an external app activates (e.g. via "Open with…")</li>
+                    <li>🧹 <strong>IMPROVED:</strong> Code quality refactor based on SonarCloud scanner issues</li>
+                </ul>
+            </div>
+
+            <!-- Version 1.5.2 -->
+            <div class="card-gradient rounded-2xl p-8">
                 <div class="flex items-baseline gap-4 mb-4 border-b border-white/5 pb-4">
                     <h3 class="font-mono text-2xl font-bold text-white">Version 1.5.2</h3>
                     <span class="version-date text-sm text-gray-500">Mar 2026</span>


### PR DESCRIPTION
fullscreen support, and include code quality improvements

- **🪟 Fullscreen Support (1.5.3)**: Quick Picker and menu bar popover now render over other apps' fullscreen Spaces — open them without leaving the app you're in
- **🔍 Smart Preview Fallback (1.5.3)**: When triggering preview inside a fullscreen app, the custom preview is used automatically (Apple Quick Look is system-managed and can't render there)
- **🛠️ Quick Picker Stability (1.5.3)**: Fixed Quick Picker pulling you out of fullscreen, improved QuickLook temp-file cleanup timing, cleaner window resignation handling
- **🧹 Code Quality (1.5.3)**: SonarCloud refactor — code quality improvements across the codebase
