### PR TITLE
Release v1.5.5

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -49,7 +49,7 @@ jobs:
           echo "Coverage report size: $(wc -l < sonar-coverage.xml) lines"
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v7
+        uses: SonarSource/sonarqube-scan-action@v8
         with:
           args: >
             -Dsonar.organization=foxfollow

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ xattr -d com.apple.quarantine /Applications/StoneClipboarderTool.app
 ## Features
 
 ### 🆕 New in Version 1.5.x
+- **🪟 Quick Picker Tabs (1.5.5)**: Filter Quick Picker by All / Favorites / Text / Images / Files; cycle tabs with Tab / Shift+Tab without losing search focus
+- **✨ Favorite from Quick Picker (1.5.5)**: Toggle favorite on the selected row with Option+Space; image rows show an OCR hint badge when OCR is enabled
+- **🛡️ Confirm-Quit (1.5.5)**: Optionally require holding ⌘Q for 1s (or a double-tap) to quit, with on-screen HUD — protects against accidental quits
+- **🎨 Sidebar Settings (1.5.5)**: Settings rebuilt as a NavigationSplitView with a sidebar; larger 720×540 minimum window size
+- **🛠️ SwiftData Stability (1.5.5)**: Fixed "backing data detached" crashes during auto-cleanup; favorites are now excluded from cleanup
+- **🛠️ Quick Look Reliability (1.5.5)**: Preview files now live in Application Support so external apps can open them; stale session files are cleaned up on launch
 - **🛠️ Apple Quick Look Fix (1.5.4)**: Fullscreen detection refined — Apple Quick Look now stays selected in regular and "Fill"/maximized windows; the Custom Preview fallback only kicks in for true "Entire Screen" Spaces
 - **⌨️ QL Arrow Navigation (1.5.4)**: ↑/↓ in Quick Picker now reliably moves the highlight and reloads the Apple Quick Look preview to the new item even when QL has grabbed the key window
 - **🪟 Fullscreen Support (1.5.3)**: Quick Picker and menu bar popover now render over other apps' fullscreen Spaces — open them without leaving the app you're in

--- a/StoneClipboarderTool.xcodeproj/project.pbxproj
+++ b/StoneClipboarderTool.xcodeproj/project.pbxproj
@@ -346,7 +346,7 @@
 				CODE_SIGN_ENTITLEMENTS = StoneClipboarderTool/StoneClipboarderTool.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = 729B6K44G8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -360,7 +360,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.5.4;
+				MARKETING_VERSION = 1.5.5;
 				PRODUCT_BUNDLE_IDENTIFIER = d3f0ld.StoneClipboarderTool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -377,7 +377,7 @@
 				CODE_SIGN_ENTITLEMENTS = StoneClipboarderTool/StoneClipboarderTool.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = 729B6K44G8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -391,7 +391,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.5.4;
+				MARKETING_VERSION = 1.5.5;
 				PRODUCT_BUNDLE_IDENTIFIER = d3f0ld.StoneClipboarderTool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/StoneClipboarderTool/Manager/SettingsManager.swift
+++ b/StoneClipboarderTool/Manager/SettingsManager.swift
@@ -21,6 +21,12 @@ class SettingsManager: ObservableObject {
         }
     }
 
+    @Published var confirmQuitOnCmdQ: Bool {
+        didSet {
+            UserDefaults.standard.set(confirmQuitOnCmdQ, forKey: "confirmQuitOnCmdQ")
+        }
+    }
+
     @Published var maxLastItems: Int {
         didSet {
             UserDefaults.standard.set(maxLastItems, forKey: "maxLastItems")
@@ -149,6 +155,7 @@ class SettingsManager: ObservableObject {
     init() {
         self.showInMenubar = UserDefaults.standard.bool(forKey: "showInMenubar")
         self.showMainWindow = UserDefaults.standard.bool(forKey: "showMainWindow")
+        self.confirmQuitOnCmdQ = UserDefaults.standard.object(forKey: "confirmQuitOnCmdQ") as? Bool ?? false
         self.maxLastItems = UserDefaults.standard.object(forKey: "maxLastItems") as? Int ?? 10
         self.maxFavoriteItems =
             UserDefaults.standard.object(forKey: "maxFavoriteItems") as? Int ?? 10

--- a/StoneClipboarderTool/StoneClipboarderToolApp.swift
+++ b/StoneClipboarderTool/StoneClipboarderToolApp.swift
@@ -25,11 +25,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var quitKeyDownMonitor: Any?
     private var quitKeyUpMonitor: Any?
     private var quitTimer: Timer?
+    private var quitDoubleTapTimer: Timer?
+    private var awaitingSecondTap = false
     private var quitHUDWindow: NSWindow?
     private var quitHUDShownAt: Date?
 
     private let quitHoldDuration: TimeInterval = 1.0
     private let quitHUDMinDisplayDuration: TimeInterval = 0.8
+    private let quitDoubleTapWindow: TimeInterval = 0.4
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Initialize app in background, even if no window appears
@@ -112,7 +115,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                   event.keyCode == 12, // Q
                   !event.isARepeat
             else { return event }
-            self.handleQuitKeyDown()
+            if self.awaitingSecondTap {
+                self.confirmQuit()
+            } else {
+                self.handleQuitKeyDown()
+            }
             return nil // consume event, prevent default quit
         }
     }
@@ -121,25 +128,35 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         showQuitHUD()
         quitTimer = Timer.scheduledTimer(withTimeInterval: quitHoldDuration, repeats: false) { [weak self] _ in
             DispatchQueue.main.async {
-                self?.hideQuitHUD()
-                NSApp.terminate(nil)
+                self?.confirmQuit()
             }
         }
         quitKeyUpMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyUp) { [weak self] event in
             if event.keyCode == 12 {
-                DispatchQueue.main.async { self?.cancelQuit() }
+                DispatchQueue.main.async { self?.handleQuitKeyUp() }
             }
             return event
         }
     }
 
-    private func cancelQuit() {
+    private func handleQuitKeyUp() {
         quitTimer?.invalidate()
         quitTimer = nil
         if let monitor = quitKeyUpMonitor {
             NSEvent.removeMonitor(monitor)
             quitKeyUpMonitor = nil
         }
+        // Start a window during which a second ⌘Q press will confirm quit
+        awaitingSecondTap = true
+        quitDoubleTapTimer = Timer.scheduledTimer(withTimeInterval: quitDoubleTapWindow, repeats: false) { [weak self] _ in
+            DispatchQueue.main.async { self?.expireDoubleTapWindow() }
+        }
+    }
+
+    private func expireDoubleTapWindow() {
+        awaitingSecondTap = false
+        quitDoubleTapTimer?.invalidate()
+        quitDoubleTapTimer = nil
         // Keep HUD visible for minimum duration so the user can read it
         let elapsed = quitHUDShownAt.map { Date().timeIntervalSince($0) } ?? quitHUDMinDisplayDuration
         let remaining = quitHUDMinDisplayDuration - elapsed
@@ -150,6 +167,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         } else {
             hideQuitHUD()
         }
+    }
+
+    private func confirmQuit() {
+        quitTimer?.invalidate()
+        quitTimer = nil
+        quitDoubleTapTimer?.invalidate()
+        quitDoubleTapTimer = nil
+        awaitingSecondTap = false
+        if let monitor = quitKeyUpMonitor {
+            NSEvent.removeMonitor(monitor)
+            quitKeyUpMonitor = nil
+        }
+        hideQuitHUD()
+        NSApp.terminate(nil)
     }
 
     private func showQuitHUD() {

--- a/StoneClipboarderTool/StoneClipboarderToolApp.swift
+++ b/StoneClipboarderTool/StoneClipboarderToolApp.swift
@@ -76,6 +76,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             menuBarManager.refreshMenuBar()
         }
 
+        // Clean up leftover preview session files from previous launches
+        QPQuickLookCoordinator.cleanupOldPreviewSessions()
+
         // Load and register hotkeys
         hotkeyManager.loadHotkeyConfigs()
 

--- a/StoneClipboarderTool/StoneClipboarderToolApp.swift
+++ b/StoneClipboarderTool/StoneClipboarderToolApp.swift
@@ -22,6 +22,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var settingsContainer: ModelContainer?
 
     private var isInitialized = false
+    private var quitKeyDownMonitor: Any?
+    private var quitKeyUpMonitor: Any?
+    private var quitTimer: Timer?
+    private var quitHUDWindow: NSWindow?
+    private var quitHUDShownAt: Date?
+
+    private let quitHoldDuration: TimeInterval = 1.0
+    private let quitHUDMinDisplayDuration: TimeInterval = 0.8
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Initialize app in background, even if no window appears
@@ -75,6 +83,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             settingsManager: settingsManager, menuBarManager: menuBarManager,
             cbViewModel: cbViewModel)
         updateWindowVisibility(settingsManager: settingsManager)
+        startQuitKeyMonitor()
     }
 
     private func updateMenuBarVisibility(
@@ -90,6 +99,89 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         } else {
             menuBarManager.hideMenuBar()
         }
+    }
+
+    private func startQuitKeyMonitor() {
+        quitKeyDownMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self,
+                  self.settingsManager?.confirmQuitOnCmdQ == true,
+                  event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+                  event.keyCode == 12, // Q
+                  !event.isARepeat
+            else { return event }
+            self.handleQuitKeyDown()
+            return nil // consume event, prevent default quit
+        }
+    }
+
+    private func handleQuitKeyDown() {
+        showQuitHUD()
+        quitTimer = Timer.scheduledTimer(withTimeInterval: quitHoldDuration, repeats: false) { [weak self] _ in
+            DispatchQueue.main.async {
+                self?.hideQuitHUD()
+                NSApp.terminate(nil)
+            }
+        }
+        quitKeyUpMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyUp) { [weak self] event in
+            if event.keyCode == 12 {
+                DispatchQueue.main.async { self?.cancelQuit() }
+            }
+            return event
+        }
+    }
+
+    private func cancelQuit() {
+        quitTimer?.invalidate()
+        quitTimer = nil
+        if let monitor = quitKeyUpMonitor {
+            NSEvent.removeMonitor(monitor)
+            quitKeyUpMonitor = nil
+        }
+        // Keep HUD visible for minimum duration so the user can read it
+        let elapsed = quitHUDShownAt.map { Date().timeIntervalSince($0) } ?? quitHUDMinDisplayDuration
+        let remaining = quitHUDMinDisplayDuration - elapsed
+        if remaining > 0 {
+            DispatchQueue.main.asyncAfter(deadline: .now() + remaining) { [weak self] in
+                self?.hideQuitHUD()
+            }
+        } else {
+            hideQuitHUD()
+        }
+    }
+
+    private func showQuitHUD() {
+        guard quitHUDWindow == nil else { return }
+        let panel = NSPanel(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.level = .floating
+        panel.ignoresMouseEvents = true
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
+
+        let hud = NSHostingView(rootView: QuitHUDView())
+        hud.frame = NSRect(origin: .zero, size: hud.fittingSize)
+        panel.contentView = hud
+        panel.setContentSize(hud.fittingSize)
+
+        if let screen = NSScreen.main {
+            let mid = screen.frame
+            let sz = panel.frame.size
+            panel.setFrameOrigin(NSPoint(x: mid.midX - sz.width / 2, y: mid.midY - sz.height / 2))
+        }
+        panel.orderFront(nil)
+        quitHUDWindow = panel
+        quitHUDShownAt = Date()
+    }
+
+    private func hideQuitHUD() {
+        quitHUDWindow?.orderOut(nil)
+        quitHUDWindow = nil
+        quitHUDShownAt = nil
     }
 
     private func updateWindowVisibility(settingsManager: SettingsManager) {
@@ -111,6 +203,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         } else {
             NSApp.setActivationPolicy(.accessory)
         }
+    }
+}
+
+// MARK: - Quit HUD
+private struct QuitHUDView: View {
+    var body: some View {
+        Text("Hold \u{2318}Q to Quit")
+            .font(.system(size: 18, weight: .bold))
+            .foregroundColor(.white)
+            .padding(.horizontal, 36)
+            .padding(.vertical, 22)
+            .background(
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(Color(white: 0.18).opacity(0.95))
+            )
     }
 }
 

--- a/StoneClipboarderTool/StoneClipboarderToolApp.swift
+++ b/StoneClipboarderTool/StoneClipboarderToolApp.swift
@@ -418,7 +418,7 @@ struct StoneClipboarderToolApp: App {
                     .environmentObject(settingsManager)
                     .environmentObject(hotkeyManager)
                     .environmentObject(cbViewModel)
-                    .frame(width: 500, height: 500)
+                    .frame(minWidth: 720, minHeight: 540)
             }
             .modelContainer(settingsContainer)
             .windowResizability(.contentSize)

--- a/StoneClipboarderTool/View/QuickPicker/QPItemList.swift
+++ b/StoneClipboarderTool/View/QuickPicker/QPItemList.swift
@@ -13,6 +13,7 @@ struct QPItemList: View {
     @Binding var searchText: String
     var isLoading: Bool = false
     var hasMoreItems: Bool = true
+    var ocrEnabled: Bool = false
     let onLoadMore: () -> Void
     let performAction: () -> Void
     var onOpenPreview: ((CBItem) -> Void)?
@@ -52,7 +53,11 @@ struct QPItemList: View {
             ScrollView {
                 LazyVStack(spacing: 0) {
                     ForEach(Array(filteredItems.enumerated()), id: \.element.id) { index, item in
-                        QPItemRow(item: item, isSelected: index == selectedIndex)
+                        QPItemRow(
+                            item: item,
+                            isSelected: index == selectedIndex,
+                            showOCRHint: ocrEnabled
+                        )
                             .id(item.id)
                             .contentShape(Rectangle())
                             .onTapGesture {

--- a/StoneClipboarderTool/View/QuickPicker/QPItemRow.swift
+++ b/StoneClipboarderTool/View/QuickPicker/QPItemRow.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct QPItemRow: View {
     let item: CBItem
     let isSelected: Bool
+    var showOCRHint: Bool = false
 
     private var typeLabel: String {
         switch item.itemType {
@@ -18,6 +19,18 @@ struct QPItemRow: View {
         case .image: return "Image"
         case .file: return "File"
         case .combined: return "Combined"
+        }
+    }
+
+    // OCR is only meaningful on image content.
+    private var isImageLike: Bool {
+        switch item.itemType {
+        case .image, .combined:
+            return true
+        case .file:
+            return item.isImageFile
+        case .text:
+            return false
         }
     }
 
@@ -58,17 +71,18 @@ struct QPItemRow: View {
 
             Spacer()
 
-            // Paste hint on selected row
+            // Inline action hints on the selected row: ⌥⏎ OCR (image-like
+            // items only, when enabled in settings), then ⏎ Paste.
             if isSelected {
-                Text("⏎")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(
-                        RoundedRectangle(cornerRadius: 4)
-                            .fill(Color.primary.opacity(0.08))
-                    )
+                HStack(spacing: 4) {
+                    if showOCRHint && isImageLike {
+                        Text("OCR:")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                        rowKeyBadge("⌥⏎", help: "Extract text (OCR)")
+                    }
+                    rowKeyBadge("⏎", help: "Paste")
+                }
             }
         }
         .padding(.horizontal, 12)
@@ -81,6 +95,19 @@ struct QPItemRow: View {
             RoundedRectangle(cornerRadius: 8)
                 .stroke(isSelected ? Color.accentColor.opacity(0.5) : Color.clear, lineWidth: 1)
         )
+    }
+
+    private func rowKeyBadge(_ key: String, help: String) -> some View {
+        Text(key)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color.primary.opacity(0.08))
+            )
+            .help(help)
     }
 
     @ViewBuilder

--- a/StoneClipboarderTool/View/QuickPicker/QPQuickLookCoordinator.swift
+++ b/StoneClipboarderTool/View/QuickPicker/QPQuickLookCoordinator.swift
@@ -16,13 +16,21 @@ class QPQuickLookCoordinator: NSObject, QLPreviewPanelDataSource, QLPreviewPanel
     private var previewURL: URL?
     private var tempDirectory: URL?
 
-    /// Prepare a CBItem for Quick Look by writing its data to a temporary file.
+    // Stable directory under Application Support so external apps (Preview.app) can always find the file.
+    private static var previewsDirectory: URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport
+            .appendingPathComponent("StoneClipboarderTool")
+            .appendingPathComponent("Previews")
+    }
+
+    /// Prepare a CBItem for Quick Look by writing its data to a stable file.
     func prepareItem(_ item: CBItem) -> Bool {
-        // Clean up previous temp files
+        // Clean up previous session files before creating a new one
         cleanupTempFiles()
 
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("StoneClipboarderQL_\(UUID().uuidString)")
+        let tempDir = QPQuickLookCoordinator.previewsDirectory
+            .appendingPathComponent("Session_\(UUID().uuidString)")
 
         do {
             try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -121,23 +129,16 @@ class QPQuickLookCoordinator: NSObject, QLPreviewPanelDataSource, QLPreviewPanel
     }
 
     /// Hide the QLPreviewPanel if visible.
-    /// Delays temp file cleanup so "Open with" actions can read the file.
+    /// Does NOT delete the session file — Preview.app or other external apps may still have it open.
+    /// The file is cleaned up when the next preview is prepared, or on app launch.
     func hidePreview() {
         if QLPreviewPanel.sharedPreviewPanelExists(),
            let panel = QLPreviewPanel.shared(),
            panel.isVisible {
             panel.orderOut(nil)
         }
-
-        // Delay cleanup so external apps launched via "Open with" have time to read the file
-        let tempDir = tempDirectory
         tempDirectory = nil
         previewURL = nil
-        if let tempDir = tempDir {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
-                try? FileManager.default.removeItem(at: tempDir)
-            }
-        }
     }
 
     /// Whether the preview panel is currently visible.
@@ -168,11 +169,26 @@ class QPQuickLookCoordinator: NSObject, QLPreviewPanelDataSource, QLPreviewPanel
             tempDirectory = nil
         }
         previewURL = nil
+        QPQuickLookCoordinator.cleanupOldPreviewSessions()
+    }
+
+    /// Removes session directories older than 1 hour that are no longer needed.
+    static func cleanupOldPreviewSessions() {
+        let dir = previewsDirectory
+        guard let contents = try? FileManager.default.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: [.creationDateKey], options: .skipsHiddenFiles
+        ) else { return }
+        let cutoff = Date().addingTimeInterval(-3600)
+        for url in contents {
+            let created = (try? url.resourceValues(forKeys: [.creationDateKey]))?.creationDate ?? .distantPast
+            if created < cutoff {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
     }
 
     deinit {
-        if let tempDir = tempDirectory {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        // Session files are intentionally kept alive so external apps (Preview.app) can still access them.
+        // Cleanup happens in cleanupTempFiles() before the next preview, or via cleanupOldPreviewSessions().
     }
 }

--- a/StoneClipboarderTool/View/QuickPicker/QuickPickerView.swift
+++ b/StoneClipboarderTool/View/QuickPicker/QuickPickerView.swift
@@ -235,18 +235,19 @@ struct QuickPickerView: View {
     private var footerBar: some View {
         Divider()
         HStack(spacing: 0) {
-            // Left side: item counts
+            // Left side: item counts (non-favorites + favorites, never summed)
             HStack(spacing: 4) {
-                Text("\(viewModel.totalItemCount) on disk")
-                Text("·")
-                Text("\(viewModel.inMemoryItemCount) in memory")
+                Text("\(viewModel.totalItemCount)")
                 if favoriteCount > 0 {
-                    Text("·")
+                    Text("+")
                     Text("\(favoriteCount)")
                     Image(systemName: "heart.fill")
                         .font(.system(size: 8))
                         .foregroundStyle(.red)
                 }
+                Text("on disk")
+                Text("·")
+                Text("\(viewModel.inMemoryItemCount) in memory")
             }
             .font(.system(size: 10))
             .foregroundStyle(.tertiary)

--- a/StoneClipboarderTool/View/QuickPicker/QuickPickerView.swift
+++ b/StoneClipboarderTool/View/QuickPicker/QuickPickerView.swift
@@ -11,8 +11,32 @@ import SwiftData
 import SwiftUI
 import Vision
 
+enum QPTab: Hashable, CaseIterable, Identifiable {
+    case all
+    case favorites
+    case text
+    case images
+    case files
+
+    var id: Self { self }
+
+    var next: QPTab {
+        let cases = QPTab.allCases
+        guard let i = cases.firstIndex(of: self) else { return .all }
+        return cases[(i + 1) % cases.count]
+    }
+
+    var previous: QPTab {
+        let cases = QPTab.allCases
+        guard let i = cases.firstIndex(of: self) else { return .all }
+        return cases[(i - 1 + cases.count) % cases.count]
+    }
+}
+
 struct QuickPickerView: View {
     @ObservedObject var viewModel: CBViewModel
+    @StateObject private var tabInterceptor = TabKeyInterceptor()
+    @State private var activeTab: QPTab = .all
     @State private var searchText = ""
     @State private var selectedIndex = 0
     @State private var quickPickerItems: [CBItem] = []
@@ -20,6 +44,9 @@ struct QuickPickerView: View {
     @State private var hasMoreItems = true
     @State private var searchTask: Task<Void, Never>?
     @State private var favoriteCount: Int = 0
+    @State private var textCount: Int = 0
+    @State private var imageCount: Int = 0
+    @State private var fileCount: Int = 0
     @FocusState private var isSearchFocused: Bool
 
     let onClose: () -> Void
@@ -45,13 +72,29 @@ struct QuickPickerView: View {
     }
 
     private var filteredItems: [CBItem] {
-        if searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return quickPickerItems
+        // Apply tab filter in-memory too so ⌥Space (unfavorite while on
+        // Favorites) and other state changes update the view without an
+        // extra disk fetch.
+        let base: [CBItem]
+        switch activeTab {
+        case .all:
+            base = quickPickerItems
+        case .favorites:
+            base = quickPickerItems.filter { $0.isFavorite }
+        case .text:
+            base = quickPickerItems.filter { $0.itemType == .text || $0.itemType == .combined }
+        case .images:
+            base = quickPickerItems.filter { $0.itemType == .image || $0.itemType == .combined }
+        case .files:
+            base = quickPickerItems.filter { $0.itemType == .file }
         }
 
         let trimmedSearch = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedSearch.isEmpty {
+            return base
+        }
 
-        return quickPickerItems.filter { item in
+        return base.filter { item in
             switch item.itemType {
             case .text, .combined:
                 if let content = item.content {
@@ -101,7 +144,12 @@ struct QuickPickerView: View {
                 }
                 return .handled
             }
-            .onKeyPress(.space) {
+            .onKeyPress(keys: [.space]) { keyPress in
+                // ⌥Space toggles favorite on the selected item.
+                if keyPress.modifiers.contains(.option) {
+                    toggleFavoriteForSelected()
+                    return .handled
+                }
                 guard triggerKey == .space else { return .ignored }
                 return handlePreviewTrigger()
             }
@@ -124,7 +172,12 @@ struct QuickPickerView: View {
                 // Cancel previous search task
                 searchTask?.cancel()
 
-                if !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty {
+                    // Favorites tab: all favorites are already in memory,
+                    // so filteredItems handles search synchronously.
+                    if activeTab == .favorites { return }
+
                     // Debounce search with 300ms delay
                     searchTask = Task {
                         try? await Task.sleep(nanoseconds: 300_000_000)
@@ -136,8 +189,14 @@ struct QuickPickerView: View {
                     }
                 } else {
                     // Reset to showing all items when search is cleared
-                    loadInitialItems()
+                    reloadForActiveTab()
                 }
+            }
+            .onChange(of: activeTab) { _, _ in
+                selectedIndex = 0
+                searchTask?.cancel()
+                reloadForActiveTab()
+                isSearchFocused = true
             }
             .onChange(of: filteredItems.count) { _, newCount in
                 if selectedIndex >= newCount {
@@ -151,6 +210,7 @@ struct QuickPickerView: View {
         VStack(spacing: 0) {
             dragHandle
             searchBar
+            tabBar
             Divider()
             QPItemList(
                 filteredItems: filteredItems,
@@ -158,6 +218,7 @@ struct QuickPickerView: View {
                 searchText: $searchText,
                 isLoading: isLoadingItems,
                 hasMoreItems: hasMoreItems,
+                ocrEnabled: settingsManager?.enableOCROptionKey == true,
                 onLoadMore: {
                     loadMoreItems()
                 },
@@ -173,7 +234,7 @@ struct QuickPickerView: View {
             )
             footerBar
         }
-        .frame(width: 500, height: 430)
+        .frame(width: 500, height: 460)
         .background(Color(NSColor.windowBackgroundColor))
         .clipShape(RoundedRectangle(cornerRadius: 10))
         .overlay(
@@ -183,10 +244,27 @@ struct QuickPickerView: View {
         .clipped()
         .onAppear {
             loadInitialItems()
-            loadFavoriteCount()
+            loadTabCounts()
+
+            // Forward-Tab and Shift-Tab cycle tabs. We intercept at the
+            // NSEvent layer because AppKit's field editor consumes Shift-Tab
+            // for focus traversal before SwiftUI's .onKeyPress runs.
+            tabInterceptor.onTab = {
+                activeTab = activeTab.next
+                isSearchFocused = true
+            }
+            tabInterceptor.onShiftTab = {
+                activeTab = activeTab.previous
+                isSearchFocused = true
+            }
+            tabInterceptor.start()
+
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 isSearchFocused = true
             }
+        }
+        .onDisappear {
+            tabInterceptor.stop()
         }
     }
 
@@ -211,7 +289,10 @@ struct QuickPickerView: View {
                 .foregroundColor(.accentColor)
                 .font(.system(size: 14, weight: .medium))
 
-            TextField("Search clipboard...", text: $searchText)
+            TextField(
+                activeTab == .favorites ? "Search favorites..." : "Search clipboard...",
+                text: $searchText
+            )
                 .textFieldStyle(.plain)
                 .focused($isSearchFocused)
                 .onSubmit {
@@ -232,46 +313,166 @@ struct QuickPickerView: View {
     }
 
     @ViewBuilder
+    private var tabBar: some View {
+        HStack(spacing: 8) {
+            ForEach(QPTab.allCases) { tab in
+                tabPill(tab)
+            }
+            Spacer()
+            tabSwitchHint
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color(NSColor.controlBackgroundColor))
+    }
+
+    // Discoverability hint: Tab cycles forward, Shift+Tab cycles backward.
+    private var tabSwitchHint: some View {
+        HStack(spacing: 4) {
+            Text("⇥")
+                .font(.system(size: 10, weight: .semibold, design: .rounded))
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(Color.primary.opacity(0.08))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 3)
+                        .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
+                )
+            Text("switch")
+                .font(.system(size: 10))
+        }
+        .foregroundStyle(.tertiary)
+        .help("Tab to switch tabs forward, Shift+Tab backward")
+    }
+
+    private func tabPill(_ tab: QPTab) -> some View {
+        let isActive = activeTab == tab
+        return Button {
+            activeTab = tab
+            // Click must NOT steal focus from the search field — otherwise
+            // shortcuts like Tab/Space/⏎ would stop working.
+            isSearchFocused = true
+        } label: {
+            HStack(spacing: 5) {
+                if tab == .favorites {
+                    Image(systemName: "heart.fill")
+                        .font(.system(size: 9))
+                        .foregroundStyle(isActive ? Color.white : .red)
+                }
+                Text(tabTitle(tab))
+                    .font(.system(size: 11, weight: .medium))
+                Text("\(tabCount(tab))")
+                    .font(.system(size: 10))
+                    .foregroundStyle(
+                        isActive ? Color.white.opacity(0.85) : Color.secondary
+                    )
+            }
+            .foregroundStyle(isActive ? Color.white : Color.primary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(
+                Capsule()
+                    .fill(isActive ? Color.accentColor : Color.clear)
+            )
+            .overlay(
+                Capsule()
+                    .stroke(
+                        isActive ? Color.clear : Color.secondary.opacity(0.35),
+                        lineWidth: 1
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .focusable(false)
+    }
+
+    private func tabTitle(_ tab: QPTab) -> String {
+        switch tab {
+        case .all: return "All"
+        case .favorites: return "Favorites"
+        case .text: return "Text"
+        case .images: return "Images"
+        case .files: return "Files"
+        }
+    }
+
+    private func tabCount(_ tab: QPTab) -> Int {
+        switch tab {
+        case .all:
+            // "All" is everything on disk, favorites included.
+            return viewModel.totalItemCount + viewModel.favoriteItemCount
+        case .favorites:
+            return favoriteCount
+        case .text:
+            return textCount
+        case .images:
+            return imageCount
+        case .files:
+            return fileCount
+        }
+    }
+
+    @ViewBuilder
     private var footerBar: some View {
         Divider()
         HStack(spacing: 0) {
-            // Left side: item counts (non-favorites + favorites, never summed)
+            // Left side: disk counts (non-favorites + favorites). No "in memory"
+            // — that's an internal detail, not useful at-a-glance.
             HStack(spacing: 4) {
                 Text("\(viewModel.totalItemCount)")
-                if favoriteCount > 0 {
+                if viewModel.favoriteItemCount > 0 {
                     Text("+")
-                    Text("\(favoriteCount)")
+                    Text("\(viewModel.favoriteItemCount)")
                     Image(systemName: "heart.fill")
                         .font(.system(size: 8))
                         .foregroundStyle(.red)
                 }
-                Text("on disk")
-                Text("·")
-                Text("\(viewModel.inMemoryItemCount) in memory")
+                Text("on Disk")
             }
             .font(.system(size: 10))
             .foregroundStyle(.tertiary)
 
             Spacer()
 
-            // Right side: keyboard shortcut hints
+            // Right side: only the shortcuts that aren't shown in the row
+            // (Paste/OCR live on the selected row now) or in the tab bar.
             HStack(spacing: 6) {
                 shortcutBadge("ESC", label: "Close")
-                shortcutBadge("⏎", label: "Paste")
+                favoriteToggleBadge()
 
                 if settingsManager?.quickLookMode != .disabled {
                     let key = settingsManager?.quickLookTriggerKey ?? .space
                     shortcutBadge(key == .space ? "⎵" : "→", label: "Preview")
-                }
-
-                if settingsManager?.enableOCROptionKey == true {
-                    shortcutBadge("⌥⏎", label: "OCR")
                 }
             }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
         .background(Color(NSColor.windowBackgroundColor))
+    }
+
+    private func favoriteToggleBadge() -> some View {
+        HStack(spacing: 3) {
+            Text("⌥⎵")
+                .font(.system(size: 9, weight: .semibold, design: .rounded))
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(Color.primary.opacity(0.08))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 3)
+                        .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
+                )
+            Image(systemName: "heart")
+                .font(.system(size: 9))
+        }
+        .foregroundStyle(.tertiary)
+        .help("Toggle favorite on the selected item")
     }
 
     private func shortcutBadge(_ key: String, label: String) -> some View {
@@ -294,15 +495,87 @@ struct QuickPickerView: View {
         .foregroundStyle(.tertiary)
     }
 
-    private func loadFavoriteCount() {
+    // Single fetch + in-memory tally. SwiftData #Predicate over String-backed
+    // enums is finicky; iterating once is simple, accurate, and cheap at
+    // typical clipboard-history sizes.
+    private func loadTabCounts() {
         guard let modelContext = viewModel.modelContext else { return }
-        let descriptor = FetchDescriptor<CBItem>(
-            predicate: #Predicate<CBItem> { $0.isFavorite }
-        )
         do {
-            favoriteCount = try modelContext.fetchCount(descriptor)
+            let all = try modelContext.fetch(FetchDescriptor<CBItem>())
+            favoriteCount = all.lazy.filter { $0.isFavorite }.count
+            textCount = all.lazy.filter { $0.itemType == .text || $0.itemType == .combined }.count
+            imageCount = all.lazy.filter { $0.itemType == .image || $0.itemType == .combined }.count
+            fileCount = all.lazy.filter { $0.itemType == .file }.count
         } catch {
             favoriteCount = 0
+            textCount = 0
+            imageCount = 0
+            fileCount = 0
+        }
+    }
+
+    private func toggleFavoriteForSelected() {
+        guard selectedIndex < filteredItems.count else { return }
+        let item = filteredItems[selectedIndex]
+        viewModel.toggleFavorite(item)
+        loadTabCounts()
+
+        // If we unfavorited an item while on the Favorites tab the row
+        // disappears (filteredItems re-filters). Clamp selection.
+        if activeTab == .favorites {
+            let newCount = filteredItems.count
+            if selectedIndex >= newCount {
+                selectedIndex = max(0, newCount - 1)
+            }
+        }
+    }
+
+    private func reloadForActiveTab() {
+        switch activeTab {
+        case .all:
+            loadInitialItems()
+        case .favorites:
+            loadFavoritesOnly()
+        case .text:
+            loadByTypes([.text, .combined])
+        case .images:
+            loadByTypes([.image, .combined])
+        case .files:
+            loadByTypes([.file])
+        }
+    }
+
+    private func loadFavoritesOnly() {
+        guard let modelContext = viewModel.modelContext else { return }
+        let descriptor = FetchDescriptor<CBItem>(
+            predicate: #Predicate<CBItem> { $0.isFavorite },
+            sortBy: [SortDescriptor(\.orderIndex, order: .forward)]
+        )
+        do {
+            quickPickerItems = try modelContext.fetch(descriptor)
+            hasMoreItems = false
+            isLoadingItems = false
+        } catch {
+            quickPickerItems = []
+            hasMoreItems = false
+            isLoadingItems = false
+        }
+    }
+
+    private func loadByTypes(_ types: [CBItemType]) {
+        guard let modelContext = viewModel.modelContext else { return }
+        let descriptor = FetchDescriptor<CBItem>(
+            sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
+        )
+        do {
+            let all = try modelContext.fetch(descriptor)
+            quickPickerItems = all.filter { types.contains($0.itemType) }
+            hasMoreItems = false
+            isLoadingItems = false
+        } catch {
+            quickPickerItems = []
+            hasMoreItems = false
+            isLoadingItems = false
         }
     }
 
@@ -565,6 +838,60 @@ private extension Array {
         indices.contains(index) ? self[index] : nil
     }
 }
+
+// MARK: - Tab key interception
+//
+// SwiftUI's `.onKeyPress(.tab)` is not reliable on macOS when a TextField has
+// focus: the field editor (NSTextView) consumes Shift-Tab for backward focus
+// traversal before SwiftUI sees it. We catch the raw key event ourselves so
+// both directions work consistently while typing in the search field.
+@MainActor
+final class TabKeyInterceptor: ObservableObject {
+    var onTab: (() -> Void)?
+    var onShiftTab: (() -> Void)?
+
+    private var monitor: Any?
+    private static let tabKeyCode: UInt16 = 48
+
+    func start() {
+        guard monitor == nil else { return }
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            self?.intercept(event) ?? event
+        }
+    }
+
+    func stop() {
+        if let m = monitor {
+            NSEvent.removeMonitor(m)
+            monitor = nil
+        }
+        onTab = nil
+        onShiftTab = nil
+    }
+
+    private func intercept(_ event: NSEvent) -> NSEvent? {
+        guard event.keyCode == Self.tabKeyCode else { return event }
+
+        let shift = event.modifierFlags.contains(.shift)
+        // Defer to next runloop tick — mutating SwiftUI state directly inside
+        // an event-dispatch callback can fight with the active event cycle.
+        DispatchQueue.main.async { [weak self] in
+            if shift {
+                self?.onShiftTab?()
+            } else {
+                self?.onTab?()
+            }
+        }
+        return nil  // swallow so the field editor doesn't move focus
+    }
+
+    deinit {
+        if let m = monitor {
+            NSEvent.removeMonitor(m)
+        }
+    }
+}
+
 
 #Preview {
     QuickPickerView(viewModel: CBViewModel()) {

--- a/StoneClipboarderTool/View/Settings/GeneralSettingsView.swift
+++ b/StoneClipboarderTool/View/Settings/GeneralSettingsView.swift
@@ -1,0 +1,231 @@
+//
+//  GeneralSettingsView.swift
+//  StoneClipboarderTool
+//
+
+import SwiftUI
+
+struct GeneralSettingsView: View {
+    @EnvironmentObject var settingsManager: SettingsManager
+    @EnvironmentObject var cbViewModel: CBViewModel
+
+    @State private var activeAlert: ClipboardAlert?
+
+    var body: some View {
+        Form {
+            AppearanceSection()
+            QuickLookSection()
+            ClipboardBehaviorSection()
+            MemoryOptimizationSection(activeAlert: $activeAlert)
+            MenuBarDisplaySection()
+            MemoryManagementSection()
+            ErrorLoggingSection()
+        }
+        .formStyle(.grouped)
+        .clipboardAlert(
+            $activeAlert,
+            onCleanup: { cbViewModel.performManualCleanup() },
+            onDeleteAll: { cbViewModel.deleteAllItems() }
+        )
+    }
+}
+
+private struct AppearanceSection: View {
+    @EnvironmentObject var settingsManager: SettingsManager
+
+    var body: some View {
+        Section("Appearance") {
+            Toggle("Show in Menu Bar", isOn: $settingsManager.showInMenubar)
+                .help("Show clipboard history in the menu bar for quick access")
+
+            Toggle("Show Main Window", isOn: $settingsManager.showMainWindow)
+                .help("Keep the main window visible in the dock")
+
+            Toggle("Hold or double-tap ⌘Q to quit", isOn: $settingsManager.confirmQuitOnCmdQ)
+                .help("Require holding ⌘Q for 1 second, or double-tapping ⌘Q, to quit — preventing accidental quits")
+        }
+    }
+}
+
+private struct QuickLookSection: View {
+    @EnvironmentObject var settingsManager: SettingsManager
+
+    var body: some View {
+        Section("Quick Look") {
+            Picker("Preview mode:", selection: $settingsManager.quickLookMode) {
+                ForEach(QuickLookMode.allCases, id: \.self) { mode in
+                    Text(mode.displayName).tag(mode)
+                }
+            }
+            .pickerStyle(.menu)
+            .help("Choose preview style when pressing the trigger key in QuickPicker")
+
+            Picker("Trigger key:", selection: $settingsManager.quickLookTriggerKey) {
+                ForEach(QuickLookTriggerKey.allCases, id: \.self) { key in
+                    Text(key.displayName).tag(key)
+                }
+            }
+            .pickerStyle(.menu)
+            .disabled(settingsManager.quickLookMode == .disabled)
+            .opacity(settingsManager.quickLookMode == .disabled ? 0.5 : 1)
+            .help("Key to open preview in QuickPicker")
+
+            Toggle("⌥ Enter to extract text (Apple Vision)", isOn: $settingsManager.enableOCROptionKey)
+                .help("When enabled, pressing Option+Enter on an image in QuickPicker will extract and paste text using Apple Vision OCR instead of the image")
+        }
+    }
+}
+
+private struct ClipboardBehaviorSection: View {
+    @EnvironmentObject var settingsManager: SettingsManager
+
+    var body: some View {
+        Section("Clipboard Behavior") {
+            VStack(alignment: .leading, spacing: 4) {
+                Picker("Clipboard capture mode:", selection: $settingsManager.clipboardCaptureMode) {
+                    ForEach(ClipboardCaptureMode.allCases, id: \.self) { mode in
+                        Text(mode.displayName).tag(mode)
+                    }
+                }
+                .pickerStyle(.menu)
+
+                Text(settingsManager.clipboardCaptureMode.description)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .help("Choose how to capture clipboard content. Files are always captured regardless of this setting.")
+        }
+    }
+}
+
+private struct MemoryOptimizationSection: View {
+    @EnvironmentObject var settingsManager: SettingsManager
+    @EnvironmentObject var cbViewModel: CBViewModel
+    @Binding var activeAlert: ClipboardAlert?
+
+    var body: some View {
+        Section("Memory Optimization") {
+            HStack(spacing: 4) {
+                Text("Items:")
+                    .foregroundColor(.secondary)
+                Text("\(cbViewModel.totalItemCount) + \(cbViewModel.favoriteItemCount) favorites on Disk")
+                    .foregroundColor(.secondary)
+                Text("·")
+                    .foregroundColor(.secondary.opacity(0.6))
+                Text("\(cbViewModel.inMemoryItemCount) in memory")
+                    .foregroundColor(.secondary)
+            }
+            .font(.caption)
+
+            Toggle("Auto-cleanup old items", isOn: $settingsManager.enableAutoCleanup)
+                .help("Automatically remove old clipboard items to maintain performance")
+
+            if settingsManager.enableAutoCleanup {
+                HStack {
+                    Text("Keep maximum items")
+                    Spacer()
+                    Stepper(value: $settingsManager.maxItemsToKeep, in: 100...5000, step: 100) {
+                        Text("\(settingsManager.maxItemsToKeep)")
+                    }
+                }
+                .help("Maximum number of items to keep before auto-cleanup")
+            }
+
+            HStack {
+                Button("Clean Up Now") { activeAlert = .cleanup }
+                    .help("Manually trigger cleanup to remove old items and free memory")
+
+                Spacer()
+
+                Button("Delete All") { activeAlert = .deleteAll }
+                    .foregroundColor(.red)
+                    .help("Delete all clipboard history items permanently")
+            }
+        }
+    }
+}
+
+private struct MenuBarDisplaySection: View {
+    @EnvironmentObject var settingsManager: SettingsManager
+
+    var body: some View {
+        Section("Menu Bar Display") {
+            HStack {
+                Text("Menu bar display items")
+                Spacer()
+                Stepper(value: $settingsManager.menuBarDisplayLimit, in: 5...50, step: 5) {
+                    Text("\(settingsManager.menuBarDisplayLimit)")
+                }
+            }
+            .help("Number of items shown in menu bar dropdown")
+        }
+    }
+}
+
+private struct MemoryManagementSection: View {
+    @EnvironmentObject var settingsManager: SettingsManager
+
+    var body: some View {
+        Section("Memory Management") {
+            Toggle("Enable memory cleanup", isOn: $settingsManager.enableMemoryCleanup)
+                .help("Automatically release memory from inactive clipboard items")
+
+            if settingsManager.enableMemoryCleanup {
+                HStack {
+                    Text("Cleanup interval (minutes)")
+                    Spacer()
+                    Stepper(value: $settingsManager.memoryCleanupInterval, in: 1...60, step: 1) {
+                        Text("\(settingsManager.memoryCleanupInterval)")
+                    }
+                }
+                .help("How often to check for inactive items")
+
+                HStack {
+                    Text("Max inactive time (minutes)")
+                    Spacer()
+                    Stepper(value: $settingsManager.maxInactiveTime, in: 5...120, step: 5) {
+                        Text("\(settingsManager.maxInactiveTime)")
+                    }
+                }
+                .help("How long items stay in memory without access")
+            }
+        }
+    }
+}
+
+private struct ErrorLoggingSection: View {
+    @EnvironmentObject var settingsManager: SettingsManager
+
+    var body: some View {
+        Section("Error Logging") {
+            Toggle("Save errors to log file", isOn: $settingsManager.enableErrorFileLogging)
+                .help("When enabled, SwiftData and other errors are saved to a .log file for debugging")
+
+            if settingsManager.enableErrorFileLogging {
+                HStack {
+                    Text("Log file size")
+                    Spacer()
+                    Text(ErrorLogger.shared.logFileSizeString)
+                        .foregroundColor(.secondary)
+                }
+
+                HStack {
+                    Button("Show in Finder") {
+                        let url = URL(fileURLWithPath: ErrorLogger.shared.logFilePath)
+                        NSWorkspace.shared.selectFile(
+                            url.path,
+                            inFileViewerRootedAtPath: url.deletingLastPathComponent().path
+                        )
+                    }
+
+                    Spacer()
+
+                    Button("Clear Log") {
+                        ErrorLogger.shared.clearLog()
+                    }
+                    .foregroundColor(.red)
+                }
+            }
+        }
+    }
+}

--- a/StoneClipboarderTool/View/Settings/SettingsDetail.swift
+++ b/StoneClipboarderTool/View/Settings/SettingsDetail.swift
@@ -1,0 +1,30 @@
+//
+//  SettingsDetail.swift
+//  StoneClipboarderTool
+//
+
+import Sparkle
+import SwiftUI
+
+struct SettingsDetail: View {
+    let section: SettingsSection
+    let updater: SPUUpdater?
+    @Binding var accessibilityGranted: Bool
+
+    var body: some View {
+        SettingsDetailContainer(subtitle: section.subtitle) {
+            content
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch section {
+        case .general:       GeneralSettingsView()
+        case .hotkeys:       HotkeySettingsView()
+        case .excludedApps:  ExcludedAppsSettingsView()
+        case .accessibility: AccessibilitySettingsView(accessibilityGranted: $accessibilityGranted)
+        case .about:         AboutSettingsView(updater: updater)
+        }
+    }
+}

--- a/StoneClipboarderTool/View/Settings/SettingsDetailContainer.swift
+++ b/StoneClipboarderTool/View/Settings/SettingsDetailContainer.swift
@@ -1,0 +1,29 @@
+//
+//  SettingsDetailContainer.swift
+//  StoneClipboarderTool
+//
+
+import SwiftUI
+
+struct SettingsDetailContainer<Content: View>: View {
+    let subtitle: String
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text(subtitle)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 8)
+            .padding(.bottom, 4)
+
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+}

--- a/StoneClipboarderTool/View/Settings/SettingsSection.swift
+++ b/StoneClipboarderTool/View/Settings/SettingsSection.swift
@@ -1,0 +1,46 @@
+//
+//  SettingsSection.swift
+//  StoneClipboarderTool
+//
+
+import Foundation
+
+enum SettingsSection: String, CaseIterable, Identifiable {
+    case general
+    case hotkeys
+    case excludedApps
+    case accessibility
+    case about
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .general: return "General"
+        case .hotkeys: return "Hotkeys"
+        case .excludedApps: return "Excluded Apps"
+        case .accessibility: return "Accessibility"
+        case .about: return "About"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .general: return "Behavior, capture, and history retention."
+        case .hotkeys: return "Global shortcuts for items, favorites, and the Quick Picker."
+        case .excludedApps: return "Apps whose clipboard content is never saved."
+        case .accessibility: return "Login behavior and macOS accessibility permission."
+        case .about: return "Version, links, and feedback."
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .general: return "gearshape"
+        case .hotkeys: return "keyboard"
+        case .excludedApps: return "lock.app.dashed"
+        case .accessibility: return "checkmark.shield"
+        case .about: return "info.circle"
+        }
+    }
+}

--- a/StoneClipboarderTool/View/Settings/SettingsSidebar.swift
+++ b/StoneClipboarderTool/View/Settings/SettingsSidebar.swift
@@ -1,0 +1,46 @@
+//
+//  SettingsSidebar.swift
+//  StoneClipboarderTool
+//
+
+import SwiftUI
+
+struct SettingsSidebar: View {
+    @Binding var selectedSection: SettingsSection
+    let accessibilityGranted: Bool
+    let appVersion: String
+
+    var body: some View {
+        VStack(spacing: 0) {
+            List(selection: $selectedSection) {
+                ForEach(SettingsSection.allCases) { section in
+                    SettingsSidebarRow(
+                        section: section,
+                        accessibilityGranted: accessibilityGranted
+                    )
+                    .tag(section)
+                }
+            }
+            .listStyle(.sidebar)
+
+            Divider()
+            SettingsSidebarFooter(appVersion: appVersion)
+        }
+        .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 260)
+    }
+}
+
+private struct SettingsSidebarFooter: View {
+    let appVersion: String
+
+    var body: some View {
+        HStack {
+            Text("v\(appVersion)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+}

--- a/StoneClipboarderTool/View/Settings/SettingsSidebarRow.swift
+++ b/StoneClipboarderTool/View/Settings/SettingsSidebarRow.swift
@@ -1,0 +1,22 @@
+//
+//  SettingsSidebarRow.swift
+//  StoneClipboarderTool
+//
+
+import SwiftUI
+
+struct SettingsSidebarRow: View {
+    let section: SettingsSection
+    let accessibilityGranted: Bool
+
+    var body: some View {
+        Label(section.title, systemImage: iconName)
+    }
+
+    private var iconName: String {
+        if section == .accessibility {
+            return accessibilityGranted ? "checkmark.shield" : "xmark.shield"
+        }
+        return section.systemImage
+    }
+}

--- a/StoneClipboarderTool/View/Settings/SettingsView.swift
+++ b/StoneClipboarderTool/View/Settings/SettingsView.swift
@@ -122,7 +122,7 @@ struct SettingsView: View {
                 HStack(spacing: 4) {
                     Text("Items:")
                         .foregroundColor(.secondary)
-                    Text("\(cbViewModel.totalItemCount) + \(cbViewModel.favoriteItemCount) favorites on disk")
+                    Text("\(cbViewModel.totalItemCount) + \(cbViewModel.favoriteItemCount) favorites on Disk")
                         .foregroundColor(.secondary)
                     Text("·")
                         .foregroundColor(.secondary.opacity(0.6))

--- a/StoneClipboarderTool/View/Settings/SettingsView.swift
+++ b/StoneClipboarderTool/View/Settings/SettingsView.swift
@@ -8,47 +8,37 @@
 import Sparkle
 import SwiftUI
 
-#if DEBUG
-    import SwiftData
-#endif
-
 struct SettingsView: View {
     @EnvironmentObject var settingsManager: SettingsManager
-    @EnvironmentObject var hotkeyManager: HotkeyManager
-    @EnvironmentObject var cbViewModel: CBViewModel
-    @Environment(\.dismiss) private var dismiss
     let updater: SPUUpdater?
 
-    @State private var selectedTab = 0
-    @State private var activeAlert: ClipboardAlert?
+    @State private var selectedSection: SettingsSection = .general
     @State private var showAutoStartPrompt = false
     @State private var accessibilityGranted = AccessibilityAlertHelper.isAccessibilityGranted
 
+    private var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+    }
+
     var body: some View {
-        VStack {
-            TabView(selection: $selectedTab) {
-                Tab("General", systemImage: "gearshape", value: 0) {
-                    generalSettings
-                }
-
-                Tab("Hotkeys", systemImage: "keyboard", value: 1) {
-                    HotkeySettingsView()
-                }
-
-                Tab("Excluded Apps", systemImage: "lock.app.dashed", value: 2) {
-                    ExcludedAppsSettingsView()
-                }
-
-                Tab("Accessibility", systemImage: accessibilityGranted ? "checkmark.shield" : "xmark.shield", value: 3) {
-                    AccessibilitySettingsView(accessibilityGranted: $accessibilityGranted)
-                }
-
-                Tab("About", systemImage: "info.circle", value: 4) {
-                    AboutSettingsView(updater: updater)
-                }
-            }
+        NavigationSplitView {
+            SettingsSidebar(
+                selectedSection: $selectedSection,
+                accessibilityGranted: accessibilityGranted,
+                appVersion: appVersion
+            )
+            .toolbar(removing: .sidebarToggle)
+        } detail: {
+            SettingsDetail(
+                section: selectedSection,
+                updater: updater,
+                accessibilityGranted: $accessibilityGranted
+            )
+            .navigationTitle(selectedSection.title)
+            .toolbar(removing: .sidebarToggle)
         }
-        .frame(width: 500, height: 500)
+        .navigationSplitViewStyle(.balanced)
+        .frame(minWidth: 720, minHeight: 540)
         .onAppear {
             if !settingsManager.hasShownAutoStartPrompt {
                 settingsManager.hasShownAutoStartPrompt = true
@@ -56,201 +46,10 @@ struct SettingsView: View {
             }
         }
         .alert("Launch at Login", isPresented: $showAutoStartPrompt) {
-            Button("Enable") {
-                settingsManager.startAtLogin = true
-            }
+            Button("Enable") { settingsManager.startAtLogin = true }
             Button("Not Now", role: .cancel) { /* No action needed for cancel */ }
         } message: {
             Text("Would you like StoneClipboarder to start automatically when you log in?\n\nYou can change this later in Settings > Accessibility or in macOS System Settings > Login Items.")
         }
     }
-
-    @ViewBuilder
-    private var generalSettings: some View {
-        Form {
-            Section("Appearance") {
-                Toggle("Show in Menu Bar", isOn: $settingsManager.showInMenubar)
-                    .help("Show clipboard history in the menu bar for quick access")
-
-                Toggle("Show Main Window", isOn: $settingsManager.showMainWindow)
-                    .help("Keep the main window visible in the dock")
-
-                Toggle("Hold or double-tap ⌘Q to quit", isOn: $settingsManager.confirmQuitOnCmdQ)
-                    .help("Require holding ⌘Q for 1 second, or double-tapping ⌘Q, to quit — preventing accidental quits")
-            }
-
-            Section("Quick Look") {
-                Picker("Preview mode:", selection: $settingsManager.quickLookMode) {
-                    ForEach(QuickLookMode.allCases, id: \.self) { mode in
-                        Text(mode.displayName).tag(mode)
-                    }
-                }
-                .pickerStyle(.menu)
-                .help("Choose preview style when pressing the trigger key in QuickPicker")
-
-                Picker("Trigger key:", selection: $settingsManager.quickLookTriggerKey) {
-                    ForEach(QuickLookTriggerKey.allCases, id: \.self) { key in
-                        Text(key.displayName).tag(key)
-                    }
-                }
-                .pickerStyle(.menu)
-                .disabled(settingsManager.quickLookMode == .disabled)
-                .opacity(settingsManager.quickLookMode == .disabled ? 0.5 : 1)
-                .help("Key to open preview in QuickPicker")
-
-                Toggle("⌥ Enter to extract text (Apple Vision)", isOn: $settingsManager.enableOCROptionKey)
-                    .help("When enabled, pressing Option+Enter on an image in QuickPicker will extract and paste text using Apple Vision OCR instead of the image")
-            }
-
-            Section("Clipboard Behavior") {
-                VStack(alignment: .leading, spacing: 4) {
-                    Picker("Clipboard capture mode:", selection: $settingsManager.clipboardCaptureMode) {
-                        ForEach(ClipboardCaptureMode.allCases, id: \.self) { mode in
-                            Text(mode.displayName).tag(mode)
-                        }
-                    }
-                    .pickerStyle(.menu)
-
-                    Text(settingsManager.clipboardCaptureMode.description)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-                .help("Choose how to capture clipboard content. Files are always captured regardless of this setting.")
-            }
-            
-            Section("Memory Optimization") {
-                HStack(spacing: 4) {
-                    Text("Items:")
-                        .foregroundColor(.secondary)
-                    Text("\(cbViewModel.totalItemCount) + \(cbViewModel.favoriteItemCount) favorites on Disk")
-                        .foregroundColor(.secondary)
-                    Text("·")
-                        .foregroundColor(.secondary.opacity(0.6))
-                    Text("\(cbViewModel.inMemoryItemCount) in memory")
-                        .foregroundColor(.secondary)
-                }
-                .font(.caption)
-
-                Toggle("Auto-cleanup old items", isOn: $settingsManager.enableAutoCleanup)
-                    .help("Automatically remove old clipboard items to maintain performance")
-
-                if settingsManager.enableAutoCleanup {
-                    HStack {
-                        Text("Keep maximum items")
-                        Spacer()
-                        Stepper(value: $settingsManager.maxItemsToKeep, in: 100...5000, step: 100) {
-                            Text("\(settingsManager.maxItemsToKeep)")
-                        }
-                    }
-                    .help("Maximum number of items to keep before auto-cleanup")
-                }
-
-                HStack {
-                    Button("Clean Up Now") {
-                        activeAlert = .cleanup
-                    }
-                    .help("Manually trigger cleanup to remove old items and free memory")
-
-                    Spacer()
-
-                    Button("Delete All") {
-                        activeAlert = .deleteAll
-                    }
-                    .foregroundColor(.red)
-                    .help("Delete all clipboard history items permanently")
-                }
-            }
-
-            Section("Menu Bar Display") {
-                HStack {
-                    Text("Menu bar display items")
-                    Spacer()
-                    Stepper(value: $settingsManager.menuBarDisplayLimit, in: 5...50, step: 5) {
-                        Text("\(settingsManager.menuBarDisplayLimit)")
-                    }
-                }
-                .help("Number of items shown in menu bar dropdown")
-            }
-
-            Section("Memory Management") {
-                Toggle("Enable memory cleanup", isOn: $settingsManager.enableMemoryCleanup)
-                    .help("Automatically release memory from inactive clipboard items")
-
-                if settingsManager.enableMemoryCleanup {
-                    HStack {
-                        Text("Cleanup interval (minutes)")
-                        Spacer()
-                        Stepper(value: $settingsManager.memoryCleanupInterval, in: 1...60, step: 1)
-                        {
-                            Text("\(settingsManager.memoryCleanupInterval)")
-                        }
-                    }
-                    .help("How often to check for inactive items")
-
-                    HStack {
-                        Text("Max inactive time (minutes)")
-                        Spacer()
-                        Stepper(value: $settingsManager.maxInactiveTime, in: 5...120, step: 5) {
-                            Text("\(settingsManager.maxInactiveTime)")
-                        }
-                    }
-                    .help("How long items stay in memory without access")
-                }
-            }
-
-            Section("Error Logging") {
-                Toggle("Save errors to log file", isOn: $settingsManager.enableErrorFileLogging)
-                    .help("When enabled, SwiftData and other errors are saved to a .log file for debugging")
-
-                if settingsManager.enableErrorFileLogging {
-                    HStack {
-                        Text("Log file size")
-                        Spacer()
-                        Text(ErrorLogger.shared.logFileSizeString)
-                            .foregroundColor(.secondary)
-                    }
-
-                    HStack {
-                        Button("Show in Finder") {
-                            let url = URL(fileURLWithPath: ErrorLogger.shared.logFilePath)
-                            NSWorkspace.shared.selectFile(url.path, inFileViewerRootedAtPath: url.deletingLastPathComponent().path)
-                        }
-
-                        Spacer()
-
-                        Button("Clear Log") {
-                            ErrorLogger.shared.clearLog()
-                        }
-                        .foregroundColor(.red)
-                    }
-                }
-            }
-        }
-        .formStyle(.grouped)
-        .clipboardAlert($activeAlert, onCleanup: {
-            cbViewModel.performManualCleanup()
-        }, onDeleteAll: {
-            cbViewModel.deleteAllItems()
-        })
-    }
 }
-//#Preview {
-//    let schema = Schema([CBItem.self])
-//    let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
-//    let container = try! ModelContainer(for: schema, configurations: [configuration])
-//    let viewModel = CBViewModel()
-//    let settingsManager = SettingsManager()
-//    let hotkeyManager = HotkeyManager()
-//    let updaterController = SPUStandardUpdaterController(
-//        startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
-//
-//    SettingsView(updater: updaterController.updater)
-//        .environmentObject(viewModel)
-//        .environmentObject(settingsManager)
-//        .environmentObject(hotkeyManager)
-//        .modelContainer(container)
-//        .onAppear {
-//            viewModel.setModelContext(container.mainContext)
-//            viewModel.setSettingsManager(settingsManager)
-//        }
-//}

--- a/StoneClipboarderTool/View/Settings/SettingsView.swift
+++ b/StoneClipboarderTool/View/Settings/SettingsView.swift
@@ -75,8 +75,8 @@ struct SettingsView: View {
                 Toggle("Show Main Window", isOn: $settingsManager.showMainWindow)
                     .help("Keep the main window visible in the dock")
 
-                Toggle("Hold ⌘Q to quit", isOn: $settingsManager.confirmQuitOnCmdQ)
-                    .help("Require holding ⌘Q for 1 seconds to quit, preventing accidental quits")
+                Toggle("Hold or double-tap ⌘Q to quit", isOn: $settingsManager.confirmQuitOnCmdQ)
+                    .help("Require holding ⌘Q for 1 second, or double-tapping ⌘Q, to quit — preventing accidental quits")
             }
 
             Section("Quick Look") {

--- a/StoneClipboarderTool/View/Settings/SettingsView.swift
+++ b/StoneClipboarderTool/View/Settings/SettingsView.swift
@@ -74,6 +74,9 @@ struct SettingsView: View {
 
                 Toggle("Show Main Window", isOn: $settingsManager.showMainWindow)
                     .help("Keep the main window visible in the dock")
+
+                Toggle("Hold ⌘Q to quit", isOn: $settingsManager.confirmQuitOnCmdQ)
+                    .help("Require holding ⌘Q for 1 seconds to quit, preventing accidental quits")
             }
 
             Section("Quick Look") {

--- a/StoneClipboarderTool/View/Settings/SettingsView.swift
+++ b/StoneClipboarderTool/View/Settings/SettingsView.swift
@@ -122,7 +122,7 @@ struct SettingsView: View {
                 HStack(spacing: 4) {
                     Text("Items:")
                         .foregroundColor(.secondary)
-                    Text("\(cbViewModel.totalItemCount) on disk")
+                    Text("\(cbViewModel.totalItemCount) + \(cbViewModel.favoriteItemCount) favorites on disk")
                         .foregroundColor(.secondary)
                     Text("·")
                         .foregroundColor(.secondary.opacity(0.6))

--- a/StoneClipboarderTool/View/Small/ActionsBottomButtonView.swift
+++ b/StoneClipboarderTool/View/Small/ActionsBottomButtonView.swift
@@ -10,15 +10,23 @@ import Vision
 
 struct ActionsBottomButtonView: View {
     @EnvironmentObject var cbViewModel: CBViewModel
-    
+
     var item: CBItem
     @Binding var editedText: String
     @Binding var isEditing: Bool
     @Binding var hasChanges: Bool
     @Binding var selectedItem: CBItem?
-    
+
+    // Guards against accessing properties on a SwiftData model whose backing
+    // data was detached (e.g. by auto-cleanup deleting it from the context).
+    // Without this, SwiftData crashes with "backing data detached from context".
+    private var isItemDeleted: Bool {
+        item.modelContext == nil
+    }
+
     // Computed property to determine if Preview button should be shown
     private var shouldShowPreviewButton: Bool {
+        guard !isItemDeleted else { return false }
         switch item.itemType {
         case .image, .combined:
             return item.image != nil
@@ -31,6 +39,7 @@ struct ActionsBottomButtonView: View {
 
     // Computed property to determine if OCR button should be shown
     private var shouldShowOCRButton: Bool {
+        guard !isItemDeleted else { return false }
         switch item.itemType {
         case .image:
             return item.image != nil
@@ -40,8 +49,18 @@ struct ActionsBottomButtonView: View {
             return false
         }
     }
-    
+
     var body: some View {
+        if isItemDeleted {
+            EmptyView()
+                .onAppear { selectedItem = nil }
+        } else {
+            actionsContent
+        }
+    }
+
+    @ViewBuilder
+    private var actionsContent: some View {
         HStack {
             Button("Copy to Clipboard") {
                 if hasChanges && isEditing {

--- a/StoneClipboarderTool/ViewModel/CBViewModel.swift
+++ b/StoneClipboarderTool/ViewModel/CBViewModel.swift
@@ -15,7 +15,10 @@ class CBViewModel: ObservableObject {
     @Published var items: [CBItem] = []
     @Published var selectedItem: CBItem?
     @Published var isLoadingMore = false
+    // Non-favorite items on disk. Favorites are tracked separately and never
+    // counted against this number, so they can't be auto-cleaned.
     @Published var totalItemCount: Int = 0
+    @Published var favoriteItemCount: Int = 0
 
     var inMemoryItemCount: Int { items.count }
 
@@ -611,7 +614,14 @@ class CBViewModel: ObservableObject {
     func refreshItemCounts() {
         guard let modelContext = _modelContext else { return }
         do {
-            totalItemCount = try modelContext.fetchCount(FetchDescriptor<CBItem>())
+            let nonFavDescriptor = FetchDescriptor<CBItem>(
+                predicate: #Predicate { !$0.isFavorite }
+            )
+            let favDescriptor = FetchDescriptor<CBItem>(
+                predicate: #Predicate { $0.isFavorite }
+            )
+            totalItemCount = try modelContext.fetchCount(nonFavDescriptor)
+            favoriteItemCount = try modelContext.fetchCount(favDescriptor)
         } catch {
             ErrorLogger.shared.log("Failed to fetch item count", category: "SwiftData", error: error)
         }
@@ -720,31 +730,58 @@ class CBViewModel: ObservableObject {
     private func performItemCountCleanupCore(maxItems: Int) {
         guard let modelContext = _modelContext else { return }
 
-        let countDescriptor = FetchDescriptor<CBItem>()
+        // The cap applies only to non-favorites. Favorites sit outside the
+        // limit and are never auto-deleted.
+        let nonFavPredicate = #Predicate<CBItem> { !$0.isFavorite }
+        let countDescriptor = FetchDescriptor<CBItem>(predicate: nonFavPredicate)
         do {
-            let totalCount = try modelContext.fetchCount(countDescriptor)
+            let nonFavCount = try modelContext.fetchCount(countDescriptor)
 
-            if totalCount > maxItems {
-                let itemsToDelete = totalCount - maxItems
-                var oldItemsDescriptor = FetchDescriptor<CBItem>(
-                    sortBy: [SortDescriptor(\.timestamp, order: .forward)]
-                )
-                oldItemsDescriptor.fetchLimit = itemsToDelete
+            guard nonFavCount > maxItems else { return }
 
-                let oldItems = try modelContext.fetch(oldItemsDescriptor)
-                let nonFavoriteOldItems = oldItems.filter { !$0.isFavorite }
+            let itemsToDelete = nonFavCount - maxItems
+            var oldItemsDescriptor = FetchDescriptor<CBItem>(
+                predicate: nonFavPredicate,
+                sortBy: [SortDescriptor(\.timestamp, order: .forward)]
+            )
+            oldItemsDescriptor.fetchLimit = itemsToDelete
 
+            let nonFavoriteOldItems = try modelContext.fetch(oldItemsDescriptor)
+
+            guard !nonFavoriteOldItems.isEmpty else { return }
+
+            // Clear UI references BEFORE detaching backing data so SwiftUI
+            // doesn't render views holding the to-be-detached items. This
+            // prevents "backing data detached from context" crashes when a
+            // currently-viewed item is auto-cleaned.
+            let idsToDelete = Set(nonFavoriteOldItems.map { $0.id })
+
+            if let sel = selectedItem, idsToDelete.contains(sel.id) {
+                selectedItem = nil
+                NotificationCenter.default.post(name: .init("ClearClipboardSelection"), object: nil)
+            }
+
+            items.removeAll { idsToDelete.contains($0.id) }
+
+            // Defer context deletion to the next run loop iteration so SwiftUI
+            // gets a full layout pass to drop views before the backing data
+            // is invalidated (mirrors deleteItem/deleteAllItems).
+            let deletedCount = nonFavoriteOldItems.count
+            DispatchQueue.main.async { [weak self] in
                 for item in nonFavoriteOldItems {
                     modelContext.delete(item)
                 }
-
-                try modelContext.save()
-
-                fetchItems(reset: true)
-
-                print(
-                    "Cleanup: Removed \(nonFavoriteOldItems.count) old items, keeping under \(maxItems) limit"
-                )
+                do {
+                    try modelContext.save()
+                    self?.fetchItems(reset: true)
+                    print(
+                        "Cleanup: Removed \(deletedCount) old items, keeping under \(maxItems) limit"
+                    )
+                } catch {
+                    modelContext.rollback()
+                    ErrorLogger.shared.log("Failed to save item count cleanup", category: "SwiftData", error: error)
+                    self?.fetchItems(reset: true)
+                }
             }
         } catch {
             ErrorLogger.shared.log("Failed to perform item count cleanup", category: "SwiftData", error: error)

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -40,8 +40,12 @@
         ><![CDATA[
             <h2>StoneClipboarderTool VERSION_NUMBER</h2>
             <ul>
-                <li>🛠️ FIXED: Apple Quick Look now stays selected in regular and "Fill"/maximized windows — fullscreen detection no longer falsely matches non-fullscreen full-size windows and only falls back to the Custom Preview when the focused app is in a true "Entire Screen" Space</li>
-                <li>⌨️ IMPROVED: Arrow navigation while Apple Quick Look is open — the search field keeps focus and ↑/↓ now reliably moves the highlight in Quick Picker, reloading the QL preview with the new item even when QL grabs key window status</li>
+                <li>🪟 NEW: Quick Picker tabs — filter by All / Favorites / Text / Images / Files; cycle tabs with Tab / Shift+Tab without losing search focus</li>
+                <li>✨ NEW: Toggle favorite on the selected Quick Picker row with Option+Space; image rows show an OCR hint badge when OCR is enabled in Settings</li>
+                <li>🛡️ NEW: Optional confirm-quit — hold ⌘Q for 1 second (or double-tap ⌘Q) to quit, with on-screen HUD; protects against accidental quits and is toggleable in Settings</li>
+                <li>🎨 IMPROVED: Settings rebuilt as a sidebar NavigationSplitView; larger 720×540 minimum window size for both Settings and the main window</li>
+                <li>🛠️ FIXED: SwiftData "backing data detached" crashes during auto-cleanup — favorites are now excluded from cleanup counts, the selected item is cleared before deletion, and context deletes are deferred with proper save/rollback</li>
+                <li>🛠️ FIXED: Quick Look previews are now written to Application Support/StoneClipboarderTool/Previews so external apps can open them; stale preview sessions older than one hour are cleaned up on launch</li>
             </ul>
         ]]></description>
         <pubDate>RELEASE_DATE</pubDate>

--- a/docs/version-history.html
+++ b/docs/version-history.html
@@ -109,9 +109,25 @@
         <!-- Version List -->
         <section class="max-w-3xl mx-auto px-4 space-y-8">
 
-            <!-- Version 1.5.4 -->
+            <!-- Version 1.5.5 -->
             <div class="card-gradient rounded-2xl p-8 relative">
                 <span class="absolute top-6 right-6 inline-flex items-center px-3 py-1 rounded-full text-xs font-bold bg-green-500/20 text-green-400 border border-green-500/30">Latest</span>
+                <div class="flex items-baseline gap-4 mb-4 border-b border-white/5 pb-4">
+                    <h3 class="font-mono text-2xl font-bold text-white">Version 1.5.5</h3>
+                    <span class="version-date text-sm text-gray-500">May 2026</span>
+                </div>
+                <ul class="space-y-3 text-gray-300 text-sm leading-relaxed list-none pl-0">
+                    <li>🪟 <strong>NEW:</strong> Quick Picker tabs — filter by All / Favorites / Text / Images / Files; cycle tabs with Tab / Shift+Tab without losing search focus</li>
+                    <li>✨ <strong>NEW:</strong> Toggle favorite on the selected Quick Picker row with Option+Space; image rows show an OCR hint badge when OCR is enabled in Settings</li>
+                    <li>🛡️ <strong>NEW:</strong> Optional confirm-quit — hold ⌘Q for 1 second (or double-tap ⌘Q) to quit, with on-screen HUD; protects against accidental quits and is toggleable in Settings</li>
+                    <li>🎨 <strong>IMPROVED:</strong> Settings rebuilt as a sidebar NavigationSplitView; larger 720×540 minimum window size for both Settings and the main window</li>
+                    <li>🛠️ <strong>FIXED:</strong> SwiftData "backing data detached" crashes during auto-cleanup — favorites are now excluded from cleanup counts, the selected item is cleared before deletion, and context deletes are deferred with proper save/rollback</li>
+                    <li>🛠️ <strong>FIXED:</strong> Quick Look previews are now written to Application Support/StoneClipboarderTool/Previews so external apps can open them; stale preview sessions older than one hour are cleaned up on launch</li>
+                </ul>
+            </div>
+
+            <!-- Version 1.5.4 -->
+            <div class="card-gradient rounded-2xl p-8">
                 <div class="flex items-baseline gap-4 mb-4 border-b border-white/5 pb-4">
                     <h3 class="font-mono text-2xl font-bold text-white">Version 1.5.4</h3>
                     <span class="version-date text-sm text-gray-500">Apr 2026</span>


### PR DESCRIPTION
  🪟 NEW: Quick Picker tabs — filter by All / Favorites / Text / Images / Files; cycle with Tab / Shift+Tab without losing search focus
  ✨ NEW: Toggle favorite on the selected Quick Picker row with Option+Space; image rows show an OCR hint badge when OCR is enabled
  🛡️  NEW: Optional confirm-quit — hold ⌘Q for 1s (or double-tap ⌘Q) to quit, with on-screen HUD; toggleable in Settings
  🎨 IMPROVED: Settings rebuilt as a sidebar NavigationSplitView; 720×540 minimum window size for Settings and the main window
  🛠️  FIXED: SwiftData "backing data detached" crashes during auto-cleanup — favorites excluded from cleanup, selection cleared before deletion, context deletes deferred with proper save/rollback
  🛠️  FIXED: Quick Look previews now written to Application Support/StoneClipboarderTool/Previews so external apps can open them; stale preview sessions older than one hour are cleaned up on launch