### PR TITLE
v1.7.0: Type-out paste in Quick Picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ xattr -d com.apple.quarantine /Applications/StoneClipboarderTool.app
 
 ## Features
 
-### 🆕 New in Version 1.6.1
+### 🆕 New in Version 1.7.0
+- **✨ Type-Out Paste**: In the Quick Picker, press ⌘⇧Return to type the selected text out character by character instead of pasting — so it lands in fields that block ⌘V (secure fields, some remote desktops and terminals)
 - **🛠️ Fix**: "Show Main Window" disabled now correctly persists across cold launches — after a reboot or login-item relaunch the app no longer reappears in the Dock and Cmd+Tab when that setting is off
 - **🧹 Improved**: Updated Sparkle auto-updater to 2.9.3
 

--- a/StoneClipboarderTool.xcodeproj/project.pbxproj
+++ b/StoneClipboarderTool.xcodeproj/project.pbxproj
@@ -346,7 +346,7 @@
 				CODE_SIGN_ENTITLEMENTS = StoneClipboarderTool/StoneClipboarderTool.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEVELOPMENT_TEAM = 729B6K44G8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -360,7 +360,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = d3f0ld.StoneClipboarderTool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -377,7 +377,7 @@
 				CODE_SIGN_ENTITLEMENTS = StoneClipboarderTool/StoneClipboarderTool.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEVELOPMENT_TEAM = 729B6K44G8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -391,7 +391,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = d3f0ld.StoneClipboarderTool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/StoneClipboarderTool/View/QuickPicker/QuickPickerView.swift
+++ b/StoneClipboarderTool/View/QuickPicker/QuickPickerView.swift
@@ -132,6 +132,12 @@ struct QuickPickerView: View {
                 return .handled
             }
             .onKeyPress(keys: [.return]) { keyPress in
+                // ⌘⇧⏎ → type the selected text out character by character
+                // instead of the normal pasteboard + ⌘V.
+                if keyPress.modifiers.contains(.command) && keyPress.modifiers.contains(.shift) {
+                    performTypePaste()
+                    return .handled
+                }
                 let optionHeld = keyPress.modifiers.contains(.option)
                 let hasMultiSelection = (selectedRange()?.count ?? 0) > 1
                 // ⌥⏎ on a Shift-extended range is always OCR intent — bypass
@@ -482,6 +488,9 @@ struct QuickPickerView: View {
                     shortcutBadge("⇧↑↓", label: "Multi-select")
                 }
                 shortcutBadge("ESC", label: "Close")
+                if selectionIsTypeable {
+                    typePasteBadge()
+                }
                 favoriteToggleBadge()
                 pinToggleBadge()
 
@@ -515,6 +524,27 @@ struct QuickPickerView: View {
         }
         .foregroundStyle(.tertiary)
         .help("Pin / unpin the selected item to the screen")
+    }
+
+    private func typePasteBadge() -> some View {
+        HStack(spacing: 3) {
+            Text("⌘⇧⏎")
+                .font(.system(size: 9, weight: .semibold, design: .rounded))
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(Color.primary.opacity(0.08))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 3)
+                        .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
+                )
+            Image(systemName: "keyboard")
+                .font(.system(size: 9))
+        }
+        .foregroundStyle(.tertiary)
+        .help("Type the selected text character by character (⌘⇧Return)")
     }
 
     private func favoriteToggleBadge() -> some View {
@@ -974,6 +1004,83 @@ struct QuickPickerView: View {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
             keyUp?.post(tap: location)
+        }
+    }
+
+    // Whether the current selection is something performTypePaste can act on:
+    // a single text/combined item with content, or a Shift-extended range
+    // that's entirely text/combined. Drives the footer hint's visibility.
+    private var selectionIsTypeable: Bool {
+        if let range = selectedRange(), range.count > 1 {
+            let items = range.compactMap { filteredItems[safe: $0] }
+            return !items.isEmpty && items.allSatisfy { isTextLikeWithContent($0) }
+        }
+        guard let item = filteredItems[safe: selectedIndex] else { return false }
+        return isTextLikeWithContent(item)
+    }
+
+    private func isTextLikeWithContent(_ item: CBItem) -> Bool {
+        (item.itemType == .text || item.itemType == .combined)
+            && (item.content?.isEmpty == false)
+    }
+
+    // "Type" paste (both ⌘ keys + Return): instead of writing to the pasteboard
+    // and simulating ⌘V, emit the text as synthetic keystrokes so it lands in
+    // apps that block programmatic paste (some password/secure fields, remote
+    // desktops, terminals). Text-only — images/files have nothing to type.
+    private func performTypePaste() {
+        let targetText: String?
+
+        if let range = selectedRange(), range.count > 1 {
+            let items = range.compactMap { filteredItems[safe: $0] }
+            guard !items.isEmpty, items.allSatisfy({ isTextLikeWithContent($0) }) else { return }
+            items.forEach { viewModel.markItemAccessed($0) }
+            targetText = items.compactMap { $0.content }.joined(separator: "\n")
+        } else {
+            guard let item = filteredItems[safe: selectedIndex],
+                  isTextLikeWithContent(item),
+                  let content = item.content else { return }
+            viewModel.markItemAccessed(item)
+            targetText = content
+        }
+
+        guard let text = targetText, !text.isEmpty else { return }
+
+        if !AccessibilityAlertHelper.isAccessibilityGranted {
+            AccessibilityAlertHelper.showAccessibilityAlert()
+            return
+        }
+
+        onClose()
+        // Let focus return to the previously-active window before typing.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            typeTextByCharacter(text)
+        }
+    }
+
+    // Posts each character as its own key-down/key-up pair carrying a Unicode
+    // string (virtualKey 0), so any character types regardless of keyboard
+    // layout. Runs off the main thread with a small inter-key delay so the
+    // receiving app can keep up; posting from a background queue is safe.
+    private func typeTextByCharacter(_ text: String) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            guard let source = CGEventSource(stateID: .hidSystemState) else { return }
+            let location = CGEventTapLocation.cghidEventTap
+
+            for character in text {
+                let utf16 = Array(String(character).utf16)
+
+                if let down = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true) {
+                    down.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: utf16)
+                    down.post(tap: location)
+                }
+                if let up = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) {
+                    up.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: utf16)
+                    up.post(tap: location)
+                }
+
+                usleep(1500)  // ~1.5ms between keystrokes
+            }
         }
     }
 

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -11,6 +11,7 @@
         <language>en</language>
 
         <new>
+            <li>✨ NEW: Type-out paste in the Quick Picker — press ⌘⇧Return to type the selected text out character by character instead of pasting, so it lands in fields that block ⌘V (secure fields, some remote desktops and terminals)</li>
             <li>🛠️ FIXED: "Show Main Window" disabled now correctly persists across cold launches — after a reboot or login-item relaunch the app no longer reappears in the Dock and Cmd+Tab when that setting is off</li>
             <li>🧹 IMPROVED: Updated Sparkle auto-updater to 2.9.3</li>
         </new>

--- a/docs/version-history.html
+++ b/docs/version-history.html
@@ -148,14 +148,15 @@
         <!-- Version List -->
         <section class="max-w-3xl mx-auto px-4 space-y-8">
 
-            <!-- Version 1.6.1 -->
+            <!-- Version 1.7.0 -->
             <div class="reveal card-gradient rounded-2xl p-8 relative">
                 <span class="absolute top-6 right-6 inline-flex items-center px-3 py-1 rounded-full text-xs font-bold bg-green-500/20 text-green-400 border border-green-500/30">Latest</span>
                 <div class="flex items-baseline gap-4 mb-4 border-b border-white/5 pb-4">
-                    <h3 class="font-mono text-2xl font-bold text-white">Version 1.6.1</h3>
-                    <span class="version-date text-sm text-gray-500">Jun 2026</span>
+                    <h3 class="font-mono text-2xl font-bold text-white">Version 1.7.0</h3>
+                    <span class="version-date text-sm text-gray-500">Jul 2026</span>
                 </div>
                 <ul class="space-y-3 text-gray-300 text-sm leading-relaxed list-none pl-0">
+                    <li>✨ <strong>NEW:</strong> Type-out paste in the Quick Picker — press ⌘⇧Return to type the selected text out character by character instead of pasting, so it lands in fields that block ⌘V (secure fields, some remote desktops and terminals).</li>
                     <li>🛠️ <strong>FIXED:</strong> "Show Main Window" disabled now correctly persists across cold launches — after a reboot or login-item relaunch the app no longer reappears in the Dock and Cmd+Tab when that setting is off.</li>
                     <li>🧹 <strong>IMPROVED:</strong> Updated Sparkle auto-updater to 2.9.3.</li>
                 </ul>


### PR DESCRIPTION
## Summary

Adds a **type-out paste** mode to the Quick Picker and prepares the **v1.7.0** release.

### Feature
- In the Quick Picker, press **⌘⇧Return** to type the selected text out **character by character** (synthetic keystrokes carrying a Unicode string, layout-independent) instead of writing to the pasteboard and simulating ⌘V.
- Works only on **text / combined** items (single, or a Shift-extended all-text range joined by newlines). Non-text selections are ignored.
- Useful for fields that block programmatic paste — secure fields, some remote desktops and terminals.
- Requires Accessibility permission (same as the existing ⌘V hotkeys); shows the standard accessibility alert if not granted.
- Footer shows a `⌘⇧⏎ ⌨️` hint badge, visible only when the current selection is typeable text.

Implementation lives entirely in `View/QuickPicker/QuickPickerView.swift`, detected via SwiftUI's existing `.onKeyPress(.return)` handler (device-independent modifiers).

### Release prep (v1.7.0)
- `MARKETING_VERSION` → 1.7.0, `CURRENT_PROJECT_VERSION` → 20 (in the feature commit).
- `docs/appcast.xml`: type-paste `<li>` prepended to the `<new>` block — feeds both the Sparkle appcast item and the GitHub release body.
- `README.md` + `docs/version-history.html` mirror the bullets. v1.6.1 was never tagged, so its startup-fix + Sparkle 2.9.3 notes fold into 1.7.0.

## Testing
- `xcodebuild ... build` succeeds (Debug, macOS).
- Type-out paste itself is paste-simulation behavior (manual per `TESTING_GUIDE.md`): select a text item, press ⌘⇧Return, confirm it types into the focused app. Needs Accessibility permission.

## After merge
Push tag `v1.7.0` to trigger `.github/workflows/release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)