### PR TITLE
Fix type-out paste typing every character as "A"

### DIFF
--- a/StoneClipboarderTool/Manager/TypePaster.swift
+++ b/StoneClipboarderTool/Manager/TypePaster.swift
@@ -4,6 +4,90 @@
 //
 
 import AppKit
+import Carbon.HIToolbox
+
+/// A physical key plus the modifiers that produce a character on the user's
+/// current keyboard layout.
+private struct KeyStroke: Sendable {
+    let keyCode: CGKeyCode
+    let flagsRawValue: UInt64
+
+    var flags: CGEventFlags { CGEventFlags(rawValue: flagsRawValue) }
+}
+
+/// Builds a character → keystroke table from the active keyboard layout.
+///
+/// Why this exists: posting a key event with `virtualKey: 0` plus a Unicode
+/// payload only works for apps that read the event's Unicode string.
+/// virtualKey 0 is literally `kVK_ANSI_A`, so anything that reads the *key
+/// code* instead — terminals, VMs, remote desktops, `KeyboardEvent.code` in a
+/// browser — sees every character as "A". Mapping each character to its real
+/// key code makes synthesized keystrokes indistinguishable from typing.
+private enum KeyboardLayoutTable {
+    static func build() -> [Character: KeyStroke] {
+        guard let inputSource = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue()
+                ?? TISCopyCurrentKeyboardInputSource()?.takeRetainedValue(),
+              let layoutPtr = TISGetInputSourceProperty(inputSource, kTISPropertyUnicodeKeyLayoutData)
+        else { return [:] }
+
+        let layoutData = unsafeBitCast(layoutPtr, to: CFData.self) as Data
+        var table: [Character: KeyStroke] = [:]
+
+        // Unmodified first, so it wins for characters reachable more than one
+        // way (the dictionary insert below only fills empty slots).
+        let combos: [(CGEventFlags, UInt32)] = [
+            ([], 0),
+            (.maskShift, UInt32(shiftKey >> 8)),
+            (.maskAlternate, UInt32(optionKey >> 8)),
+            ([.maskShift, .maskAlternate], UInt32((shiftKey | optionKey) >> 8)),
+        ]
+
+        layoutData.withUnsafeBytes { raw in
+            guard let layout = raw.baseAddress?.assumingMemoryBound(to: UCKeyboardLayout.self) else {
+                return
+            }
+            let keyboardType = UInt32(LMGetKbdType())
+
+            for (flags, carbonModifiers) in combos {
+                for keyCode in UInt16(0)..<128 {
+                    var deadKeyState: UInt32 = 0
+                    var chars = [UniChar](repeating: 0, count: 4)
+                    var length = 0
+
+                    let status = UCKeyTranslate(
+                        layout,
+                        keyCode,
+                        UInt16(kUCKeyActionDown),
+                        carbonModifiers,
+                        keyboardType,
+                        OptionBits(1 << kUCKeyTranslateNoDeadKeysBit),
+                        &deadKeyState,
+                        chars.count,
+                        &length,
+                        &chars
+                    )
+
+                    guard status == noErr, length == 1,
+                          let scalar = Unicode.Scalar(chars[0]),
+                          scalar.value >= 32  // skip control chars, handled below
+                    else { continue }
+
+                    let character = Character(scalar)
+                    if table[character] == nil {
+                        table[character] = KeyStroke(keyCode: CGKeyCode(keyCode), flagsRawValue: flags.rawValue)
+                    }
+                }
+            }
+        }
+
+        // Whitespace the layout tables don't yield as printable scalars.
+        table["\n"] = KeyStroke(keyCode: CGKeyCode(kVK_Return), flagsRawValue: 0)
+        table["\r"] = KeyStroke(keyCode: CGKeyCode(kVK_Return), flagsRawValue: 0)
+        table["\t"] = KeyStroke(keyCode: CGKeyCode(kVK_Tab), flagsRawValue: 0)
+
+        return table
+    }
+}
 
 /// Types text out as synthetic keystrokes, character by character, so it lands
 /// in fields that block programmatic paste (⌘V). Owned by
@@ -40,6 +124,7 @@ final class TypePaster {
         // Floor at 1 ms: with zero delay the OS coalesces/drops the burst of
         // synthetic events and little or nothing actually gets typed.
         let delayMicroseconds = UInt32(max(1, charDelayMs)) * 1000
+        let layout = KeyboardLayoutTable.build()
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             defer { Task { @MainActor in self?.finish() } }
@@ -47,21 +132,65 @@ final class TypePaster {
             guard let source = CGEventSource(stateID: .hidSystemState) else { return }
             let location = CGEventTapLocation.cghidEventTap
 
+            // The trigger chord (⌘⇧Return) is usually still physically held at
+            // this point; those modifiers would combine with the first
+            // keystrokes (uppercase, or worse, fire shortcuts). Let go first.
+            Self.waitForModifierRelease(token: token)
+
             for character in text {
                 if token.isCancelled { break }
-
-                let utf16 = Array(String(character).utf16)
-                if let down = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true) {
-                    down.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: utf16)
-                    down.post(tap: location)
-                }
-                if let up = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) {
-                    up.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: utf16)
-                    up.post(tap: location)
-                }
-
+                Self.post(character, layout: layout, source: source, location: location)
                 usleep(delayMicroseconds)
             }
+        }
+    }
+
+    /// Block until the user releases every modifier, or ~1s passes.
+    nonisolated private static func waitForModifierRelease(token: CancelToken) {
+        let interesting: CGEventFlags = [.maskCommand, .maskShift, .maskAlternate, .maskControl]
+        var waitedMicroseconds = 0
+        while waitedMicroseconds < 1_000_000 {
+            if token.isCancelled { return }
+            let held = CGEventSource.flagsState(.combinedSessionState)
+            if held.intersection(interesting).isEmpty { return }
+            usleep(20_000)
+            waitedMicroseconds += 20_000
+        }
+    }
+
+    nonisolated private static func post(
+        _ character: Character,
+        layout: [Character: KeyStroke],
+        source: CGEventSource,
+        location: CGEventTapLocation
+    ) {
+        if let stroke = layout[character] {
+            // Real key code + explicit flags: key-code readers see the right
+            // key, and setting flags outright stops any still-held physical
+            // modifier from leaking into the event.
+            if let down = CGEvent(keyboardEventSource: source, virtualKey: stroke.keyCode, keyDown: true) {
+                down.flags = stroke.flags
+                down.post(tap: location)
+            }
+            if let up = CGEvent(keyboardEventSource: source, virtualKey: stroke.keyCode, keyDown: false) {
+                up.flags = stroke.flags
+                up.post(tap: location)
+            }
+            return
+        }
+
+        // Unreachable on this layout (emoji, other scripts): fall back to a
+        // Unicode payload. Key-code readers can't represent these anyway.
+        let utf16 = Array(String(character).utf16)
+        if let down = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true) {
+            down.flags = []
+            down.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: utf16)
+            down.post(tap: location)
+        }
+        if let up = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) {
+            up.flags = []
+            up.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: utf16)
+            up.post(tap: location)
         }
     }
 


### PR DESCRIPTION
## The bug

Type-out paste (⌘⇧Return) typed the wrong characters. Two distinct causes, both visible in testing:

**1. Every character came out as "A".** Events were posted with `virtualKey: 0` plus a Unicode payload. That works for apps reading the event's Unicode string — but `virtualKey 0` is literally `kVK_ANSI_A`, so anything reading the **key code** sees "A". That includes terminals, VMs, remote desktops, and `KeyboardEvent.code` in a browser — exactly the apps type-out paste exists to serve (they're the ones that block ⌘V).

Confirmed against a Parrot/Konsole VM (typed `aaaaaa…`) and `keyboard-test.space` (reported `<A>` for every keystroke).

**2. A leading `AAAA` before the `aaaa`.** Events set no flags, so they inherited the ⌘⇧ still physically held from the trigger chord. The first characters were typed with Shift down.

## The fix

- **Real key codes.** New `KeyboardLayoutTable` builds a `Character → (keyCode, modifiers)` map from the **active keyboard layout** via `UCKeyTranslate`, probing all 128 key codes across none/⇧/⌥/⇧⌥ (unmodified wins ties). Characters are posted with their real key code and modifiers, so keystrokes are indistinguishable from real typing. Rebuilt per run, so layout switches (e.g. ЙЦУКЕН) are picked up.
- **Return/Tab** mapped explicitly (layout tables don't yield them as printable scalars).
- **Fallback preserved:** characters unreachable on the layout (emoji, other scripts) still use the Unicode-payload path — key-code readers can't represent those anyway.
- **No modifier leakage:** every event sets `flags` explicitly (including empty), and typing now waits (up to 1s, cancellable) for the trigger chord to be released before starting.

## Testing

- `xcodebuild ... build` succeeds (Debug, macOS).
- Paste-simulation is manual (needs Accessibility). Worth re-checking both failing spots: a terminal/VM prompt, and `keyboard-test.space` — it should now light up the actual keys instead of `<A>`.
- Cancellation is unchanged and should still work: Escape, or reopening the Quick Picker, halts an in-progress type-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)