### PR TITLE
v1.7.3: re-release the type-out paste fix (v1.7.2 was broken)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,9 @@ xattr -d com.apple.quarantine /Applications/StoneClipboarderTool.app
 
 ## Features
 
-### 🆕 New in Version 1.7.1
-- **✨ Quick Picker Settings Tab**: A dedicated Quick Picker tab in Settings — Quick Look preview options plus the new type-out paste controls
-- **⌨️ Adjustable Type-Out Speed**: Set the per-character delay for type-out paste (⌘⇧Return) — raise it for text fields that drop characters when typing too fast
-- **⌨️ Cancel Type-Out**: Stop an in-progress type-out anytime by pressing Escape or reopening the Quick Picker
+### 🆕 New in Version 1.7.3
+- **🛠️ Type-Out Paste Fix**: Type-out paste (⌘⇧Return) typed every character as "A" in apps that read key codes — terminals, virtual machines, remote desktops. Characters are now sent using the real key for your active keyboard layout
+- **🐛 Modifier Fix**: Type-out paste no longer picks up the ⌘⇧ still held from the trigger shortcut, which typed the first few characters in uppercase
 
 **📖 [See the full changelog →](https://foxfollow.github.io/Stone-Clipboarder-Tool/version-history.html)**
 

--- a/StoneClipboarderTool.xcodeproj/project.pbxproj
+++ b/StoneClipboarderTool.xcodeproj/project.pbxproj
@@ -346,7 +346,7 @@
 				CODE_SIGN_ENTITLEMENTS = StoneClipboarderTool/StoneClipboarderTool.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 729B6K44G8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -360,7 +360,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.7.3;
 				PRODUCT_BUNDLE_IDENTIFIER = d3f0ld.StoneClipboarderTool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -377,7 +377,7 @@
 				CODE_SIGN_ENTITLEMENTS = StoneClipboarderTool/StoneClipboarderTool.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 729B6K44G8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -391,7 +391,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.7.3;
 				PRODUCT_BUNDLE_IDENTIFIER = d3f0ld.StoneClipboarderTool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -10,26 +10,11 @@
         <description>Updates for StoneClipboarderTool</description>
         <language>en</language>
 
-    <item>
-        <title>Version 1.7.1</title>
-        <link>https://foxfollow.github.io/Stone-Clipboarder-Tool/</link>
-        <sparkle:version>21</sparkle:version>
-        <sparkle:shortVersionString>1.7.1</sparkle:shortVersionString>
-        <description
-        ><![CDATA[
-            <h2>Version 1.7.1</h2>
-            <p>See release notes on GitHub for details.</p>
-        ]]></description>
-        <pubDate>Mon, 20 Jul 2026 20:41:59 +0000</pubDate>
-        <enclosure
-            url="https://github.com/foxfollow/Stone-Clipboarder-Tool/releases/download/v1.7.1/StoneClipboarderTool.zip"
-            sparkle:version="21"
-            sparkle:shortVersionString="1.7.1"
-            sparkle:edSignature="9h5JnJ/GbqJpunYv7rQrCGO8ChiVZXYQSRxLMXQ6Y2mO3YOF0DPhWoksuy+O/lSGtYXgQPduT2emomv3uZepBA=="
-            length="5656797"
-            type="application/octet-stream"
-        />
-    </item>
+        <new>
+            <li>🛠️ FIXED: Type-out paste (⌘⇧Return) typed every character as "A" in apps that read key codes — terminals, virtual machines, remote desktops. Characters are now sent using the real key for your active keyboard layout</li>
+            <li>🐛 FIXED: Type-out paste no longer picks up the ⌘⇧ still held from the trigger shortcut, which typed the first few characters in uppercase</li>
+        </new>
+
 
     <item>
         <title>Version 1.7.1</title>

--- a/docs/version-history.html
+++ b/docs/version-history.html
@@ -148,9 +148,21 @@
         <!-- Version List -->
         <section class="max-w-3xl mx-auto px-4 space-y-8">
 
-            <!-- Version 1.7.1 -->
+            <!-- Version 1.7.3 -->
             <div class="reveal card-gradient rounded-2xl p-8 relative">
                 <span class="absolute top-6 right-6 inline-flex items-center px-3 py-1 rounded-full text-xs font-bold bg-green-500/20 text-green-400 border border-green-500/30">Latest</span>
+                <div class="flex items-baseline gap-4 mb-4 border-b border-white/5 pb-4">
+                    <h3 class="font-mono text-2xl font-bold text-white">Version 1.7.3</h3>
+                    <span class="version-date text-sm text-gray-500">Jul 2026</span>
+                </div>
+                <ul class="space-y-3 text-gray-300 text-sm leading-relaxed list-none pl-0">
+                    <li>🛠️ <strong>FIXED:</strong> Type-out paste (⌘⇧Return) typed every character as "A" in apps that read key codes — terminals, virtual machines, remote desktops. Characters are now sent using the real key for your active keyboard layout.</li>
+                    <li>🐛 <strong>FIXED:</strong> Type-out paste no longer picks up the ⌘⇧ still held from the trigger shortcut, which typed the first few characters in uppercase.</li>
+                </ul>
+            </div>
+
+            <!-- Version 1.7.1 -->
+            <div class="reveal card-gradient rounded-2xl p-8">
                 <div class="flex items-baseline gap-4 mb-4 border-b border-white/5 pb-4">
                     <h3 class="font-mono text-2xl font-bold text-white">Version 1.7.1</h3>
                     <span class="version-date text-sm text-gray-500">Jul 2026</span>


### PR DESCRIPTION
## Why v1.7.2 was broken

**v1.7.2 was tagged without bumping the version.** `release.yml` reads the version from the *built app's* `Info.plist`, which still said `1.7.1` / build `21`. So the release produced:

- an appcast item titled **"Version 1.7.1"** with `sparkle:version 21` — a **duplicate** of the existing 1.7.1 entry;
- an enclosure URL pointing at the **v1.7.1** asset, but carrying the signature of the **v1.7.2** build — so that signature would not have verified;
- release notes falling back to "See release notes on GitHub for details." (no `<new>` block existed).

Sparkle never offered the update, because `sparkle:version 21` matched what users already had. The fix itself never reached anyone.

The **v1.7.2 tag and GitHub release have been deleted** (v1.7.1 is Latest again). This PR re-ships the fix as **v1.7.3**.

## Changes

- **`project.pbxproj`**: `MARKETING_VERSION` 1.7.1 → **1.7.3**, `CURRENT_PROJECT_VERSION` 21 → **22**.
  Verified by building: the app's `Info.plist` now reports `CFBundleShortVersionString 1.7.3` / `CFBundleVersion 22` — exactly what the workflow reads, so the appcast item will be correct this time.
- **`docs/appcast.xml`**: removed the bogus duplicate 1.7.1 item the v1.7.2 run wrote, and added the `<new>` block (single source for both the Sparkle item and the GitHub release body). XML validated with `xmllint`.
- **`README.md`**: "New in Version" → 1.7.3.
- **`docs/version-history.html`**: new 1.7.3 card with the "Latest" pill (removed from 1.7.1). Verified exactly one "Latest" pill.

No `index.html` carousel slide — this is a bugfix release.

## Note on Homebrew

The workflow auto-bumped the Homebrew cask to 1.7.2, whose asset is now deleted, so `brew install` will 404 until v1.7.3 is tagged. Tagging promptly after merge closes that window.

## After merge

```
git checkout main && git pull
git tag v1.7.3 && git push origin v1.7.3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)